### PR TITLE
Modified profiles_gen to handle fast alphas in the netcdf iterdb file.

### DIFF
--- a/shared/profiles_gen/src/allocate_iterdb_vars.f90
+++ b/shared/profiles_gen/src/allocate_iterdb_vars.f90
@@ -8,6 +8,7 @@ subroutine allocate_iterdb_vars
   allocate(onetwo_te(onetwo_nj))
   allocate(onetwo_rho_grid(onetwo_nj))
   allocate(onetwo_ene(onetwo_nj))
+  allocate(onetwo_enalp(onetwo_nj))
   allocate(onetwo_zeff(onetwo_nj))
   allocate(onetwo_angrot(onetwo_nj))
   allocate(onetwo_psi(onetwo_nj))
@@ -52,5 +53,9 @@ subroutine allocate_iterdb_vars
   allocate(sbcx_d(onetwo_nj)) 
   allocate(onetwo_sbeam(onetwo_nj)) 
   allocate(onetwo_storqueb(onetwo_nj))
+  
+  
+  allocate(onetwo_enion_vec(onetwo_nion+onetwo_nbion+1,onetwo_nj))
+  allocate(onetwo_Tion_vec(onetwo_nion+onetwo_nbion+1,onetwo_nj))
 
 end subroutine allocate_iterdb_vars

--- a/shared/profiles_gen/src/prgen_globals.f90
+++ b/shared/profiles_gen/src/prgen_globals.f90
@@ -86,6 +86,7 @@ module prgen_globals
   character (len=2), dimension(5) :: onetwo_namep
   character (len=2), dimension(5) :: onetwo_namei
   character (len=2), dimension(5) :: onetwo_nameb
+  character (len=2), dimension(16) :: onetwo_ion_name
   real :: onetwo_time
   real :: onetwo_Rgeom
   real :: onetwo_Rmag
@@ -116,10 +117,12 @@ module prgen_globals
   real, dimension(:), allocatable :: onetwo_sbeam
   real, dimension(:), allocatable :: onetwo_te
   real, dimension(:), allocatable :: onetwo_ti
+  real, dimension(:), allocatable :: onetwo_talp
   real, dimension(:), allocatable :: onetwo_q
   real, dimension(:), allocatable :: onetwo_angrot
   real, dimension(:), allocatable :: onetwo_zeff
   real, dimension(:), allocatable :: onetwo_ene
+  real, dimension(:), allocatable :: onetwo_enalp
   real, dimension(:), allocatable :: onetwo_psi
   real, dimension(:), allocatable :: onetwo_storqueb
   real, dimension(:), allocatable :: onetwo_press
@@ -142,6 +145,11 @@ module prgen_globals
   real, dimension(:), allocatable :: onetwo_elongxnpsi
   real, dimension(:), allocatable :: onetwo_triangnpsi_u
   real, dimension(:), allocatable :: onetwo_triangnpsi_l
+  !
+  ! conglomerate ion vectors
+  !
+  real, dimension(:,:), allocatable :: onetwo_enion_vec
+  real, dimension(:,:), allocatable :: onetwo_Tion_vec  
   !---------------------------------------------------------
 
   !---------------------------------------------------------

--- a/shared/profiles_gen/src/prgen_read_iterdb_nc.f90
+++ b/shared/profiles_gen/src/prgen_read_iterdb_nc.f90
@@ -117,6 +117,9 @@ subroutine prgen_read_iterdb_nc
 
   err = nf90_inq_varid(ncid,trim('enbeam'),varid)
   err = nf90_get_var(ncid,varid,onetwo_enbeam(:,1:onetwo_nbion))
+  
+  err = nf90_inq_varid(ncid,trim('enalp'),varid)
+  err = nf90_get_var(ncid,varid,onetwo_enalp)
 
   ! Total plasma pressure
   err = nf90_inq_varid(ncid,trim('press'),varid)

--- a/shared/profiles_gen/src/prgen_write.f90
+++ b/shared/profiles_gen/src/prgen_write.f90
@@ -41,7 +41,7 @@ subroutine prgen_write
      write(1,40) '#          SHOT NUMBER : ',onetwo_ishot
      write(1,20) '#'
      write(1,'(10(a,1x))') '#                 IONS : ',&
-          (trim(ion_name(reorder_vec(i))),i=1,onetwo_nion+onetwo_nbion)
+          (trim(onetwo_ion_name(reorder_vec(i))),i=1,min(onetwo_nion+onetwo_nbion+1,5))
 
   case (2)
      write(1,20) '#              TOKAMAK : ',trim(plst_tokamak_id)


### PR DESCRIPTION
The logic includes changing the fast alpha temperature similar to how the
beam effective temperatures are modified.  There is also logic added to be
able to reorder ions whose index is greater than 5 (for iterdb files).  As well
there is logic to ignore zero density alpha or beam species.  These changes
are necessary to be able to handle the iterdb files for FNSF.
