### PR TITLE
Fixed scaling of auxiliary power for loc_scenario=3.

### DIFF
--- a/tgyro/src/tgyro_source.f90
+++ b/tgyro/src/tgyro_source.f90
@@ -144,13 +144,13 @@ subroutine tgyro_source
 
      p_i(:) = &
           +p_i_fus(:) &                ! Fusion power to ions
-          +p_i_aux_in(:) &             ! Auxiliary ion heating [fixed]
+          +tgyro_input_paux_scale*p_i_aux_in(:) &             ! Auxiliary ion heating [fixed]
           +p_exch(:) &                 ! Collisional exchange
           +p_expwd(:)*tgyro_expwd_flag ! Turbulent exchange
 
      p_e(:) = &
           +p_e_fus(:) &                ! Fusion power to electrons
-          +p_e_aux_in(:) &             ! Auxiliary electron heating [fixed]
+          +tgyro_input_paux_scale*p_e_aux_in(:) &             ! Auxiliary electron heating [fixed]
           -p_exch(:)   &               ! Collisional exchange
           -p_brem(:) &                 ! Bremsstrahlung radiation
           -p_sync(:) &                 ! Synchrotron radiation


### PR DESCRIPTION
For `loc_scenario==1` or `loc_scenario==2`, `p_e` and `p_i` are calculated from `p_e_in` and `p_i_in`, which have been scaled by `tgyro_input_paux_scale`, but for `loc_scenario==3`, `p_e` is calculated from `'p_e_aux_in`, which has not been scaled (likewise for `p_i`).  This fix/pull request makes the meaning of the scaling consistent in practice, but it is possible that @jcandy would like it fixed differently.
