### PR TITLE
New file format

### DIFF
--- a/shared/EXPRO/expro_vars.txt
+++ b/shared/EXPRO/expro_vars.txt
@@ -1,0 +1,469 @@
+----
+Variable: EXPRO_error
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_n_ion_max
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_n_ion
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_n_exp
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_b_ref
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_arho
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_null_tag
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_rho
+Description: 
+Units: -
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_rmin
+Description: 
+Units: m
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_rmaj
+Description: 
+Units: m
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_q
+Description: 
+Units: -
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_kappa
+Description: 
+Units: -
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_delta
+Description: 
+Units: -
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_z_eff
+Description: 
+Units: -
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_w0
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_flow_mom
+Description: 
+Units: n-m
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_sbcx
+Description: 
+Units: /m^3/s
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_sbeame
+Description: 
+Units: /m^3/s
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_sscxl
+Description: 
+Units: /m^3/s
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_e
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_i
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_ei
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_zeta
+Description: 
+Units: -
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_flow_beam
+Description: 
+Units: kw/ev
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_flow_wall
+Description: 
+Units: kw/ev
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_zmag
+Description: 
+Units: m
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_ptot
+Description: 
+Units: pa
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_polflux
+Description: 
+Units: wb/rad
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_e_fus
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_i_fus
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_e_sync
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_e_brem
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_e_line
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_e_aux
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_pow_i_aux
+Description: 
+Units: MW
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_ne
+Description: 
+Units: 10^19/m^3
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_ni
+Description: 
+Units: 10^19/m^3
+Dimensions: 2
+Dimension 1: rho
+Dimension 2: ions
+----
+Variable: EXPRO_te
+Description: 
+Units: keV
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_ti
+Description: 
+Units: keV
+Dimensions: 2
+Dimension 1: rho
+Dimension 2: ions
+----
+Variable: EXPRO_vtor
+Description: 
+Units: m/s
+Dimensions: 2
+Dimension 1: rho
+Dimension 2: ions
+----
+Variable: EXPRO_vpol
+Description: 
+Units: m/s
+Dimensions: 2
+Dimension 1: rho
+Dimension 2: ions
+----
+Variable: EXPRO_bunit
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_s
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_drmaj
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_dzmag
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_sdelta
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_skappa
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_szeta
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_dlnnedr
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_dlntedr
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_dlnnidr
+Description: 
+Units: ?
+Dimensions: 2
+Dimension 1: rho
+Dimension 2: ions
+----
+Variable: EXPRO_dlntidr
+Description: 
+Units: ?
+Dimensions: 2
+Dimension 1: rho
+Dimension 2: ions
+----
+Variable: EXPRO_dlnptotdr
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_w0p
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_vol
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_volp
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_cs
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_rhos
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_ni_new
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_dlnnidr_new
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_grad_r0
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_ave_grad_r
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_drdrho
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_bp0
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_bt0
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_nfourier
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_geo
+Description: 
+Units: ?
+Dimensions: 3
+Dimension 1: rho
+Dimension 2: ions
+Dimension 3:?
+----
+Variable: EXPRO_dgeo
+Description: 
+Units: ?
+Dimensions: 3
+Dimension 1: rho
+Dimension 2: ions
+Dimension 3:?
+----
+Variable: EXPRO_gamma_e
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_gamma_p
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_mach
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_thetascale
+Description: 
+Units: ?
+Dimensions: 1
+Dimension 1: rho
+----
+Variable: EXPRO_signb
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_signq
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_ctrl_quasineutral_flag
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_ctrl_n_ion
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_ctrl_z
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_ctrl_numeq_flag
+Description: 
+Units: ?
+Dimensions: 0
+----
+Variable: EXPRO_ctrl_silent_flag
+Description: 
+Units: ?
+Dimensions: 0

--- a/shared/EXPRO/parse_EXPRO_interface.py
+++ b/shared/EXPRO/parse_EXPRO_interface.py
@@ -1,0 +1,66 @@
+#!/opt/local/bin/python
+
+with open('EXPRO_interface.f90','r') as f:
+    fl = f.readlines()
+var_names = []
+tags = {}
+dims = {}
+for l in fl:
+    ll = l.lower().strip().split('!')[0]
+    if not ll:
+        continue
+    if '::' in ll:
+        dim = 0
+        if 'dimension' in ll:
+            dim = ll.split('::')[0].count(':')
+        for var0 in ll.split('::')[1].split(','):
+            var = var0.strip()
+            if '=' in var:
+                var_name,val = map(str.strip,var.split('='))
+            else:
+                var_name = var.strip()
+                val = 'not set'
+            if var_name.endswith('_tag') and var_name[:-4] in var_names:
+                try:
+                    tags[var_name[:-4]] = eval(val)
+                except:
+                    tags[var_name[:-4]] = val
+            else:
+                var_names.append(var_name)
+                dims[var_name] = dim
+quants_per_ion = ['ti','vpol','ni','vtor']
+print var_names
+print tags
+units = {
+            'ti': 'keV',
+            'ni': '10^19/m^3',
+            'vpol': 'm/s',
+            'vtor': 'm/s'
+        }
+for k,v in tags.items():
+    tag,unit = v.split('(',2)[0:2]
+    unit = ')'.join(unit.split(')')[:-1])
+    if k[len('expro_'):]!=tag:
+        print k,tag
+        continue
+    if tag in units:
+        continue
+    units[tag] = unit 
+    if '(/' in v and '(/m' not in v:
+        print k
+print units
+print dims
+with open('expro_vars.txt','w') as f:
+    for k in var_names:
+        f.write('----\n')
+        f.write('Variable: %s\n'%k.replace('expro_','EXPRO_'))
+        f.write('Description: \n')
+        f.write('Units: %s\n'%units.get(k.replace('expro_',''),'?').replace('mw','MW').replace('kev','keV'))
+        f.write('Dimensions: %d\n'%dims[k])
+        if dims[k]>0:
+            f.write('Dimension 1: rho\n')
+            if dims[k]>1:
+                f.write('Dimension 2: ions\n')
+                if dims[k]>2:
+                    for d in range(3,dims[k]+1):
+                        f.write('Dimension %d:?\n'%d)


### PR DESCRIPTION
@orso82 @jcandy @bellie @jkinsey 
I started this branch with a parsing of the `EXPRO_interface.f90` file to produce the `expro_vars.txt` file skeleton, which we need to fill in with the missing descriptions, if the skeleton is of the desired form.   We can then write the new file format writer/reader based on the completed `expro_vars.txt` file.
- [x] Parse existing `EXPRO_interface.f90` file to get variable names and units
- [ ] Fill in missing details in the `expro_vars.txt` file
  - [ ] Do we need any more attributes, such as data_source?
  - [ ] Do we need the topic attribute?
  - [ ] Do we want the mapping to a new variable name (such as exist in iterdb.nc currently)?
- [ ] Write the automatic generator for the flexible and dynamic writer/reader

Let's discuss further developments in this pull request.
