### PR TITLE
tgyro_zero_dens_grad_flag addition

### DIFF
--- a/tgyro/bin/tgyro_parse.py
+++ b/tgyro/bin/tgyro_parse.py
@@ -110,6 +110,7 @@ x.add('TGYRO_PED_RATIO','-0.92')
 x.add('TGYRO_PED_SCALE','1.0')
 x.add('TGYRO_TGLF_NN_MAX_ERROR','-1')
 x.add('TGYRO_QUICKFAST_FLAG','0')
+x.add('TGYRO_ZERO_DENS_GRAD_FLAG','0')
 
 # Deprecated parameters
 x.dep('LOC_N_FEEDBACK','new parameter is LOC_NE_FEEDBACK_FLAG')

--- a/tgyro/src/tgyro_globals.f90
+++ b/tgyro/src/tgyro_globals.f90
@@ -324,6 +324,7 @@ module tgyro_globals
   real :: tgyro_ped_scale
   real :: tgyro_tglf_nn_max_error
   integer :: tgyro_quickfast_flag
+  integer :: tgyro_zero_dens_grad_flag
   !
   ! Iteration variables (global)
   !

--- a/tgyro/src/tgyro_neo_map.f90
+++ b/tgyro/src/tgyro_neo_map.f90
@@ -88,6 +88,11 @@ subroutine tgyro_neo_map
      neo_dlntdr_in(i0) = r_min*dlntidr(is,i_r)
   enddo
 
+  ! Setting density gradient artificially to zero to compute D and v
+  if (tgyro_zero_dens_grad_flag /= 0) then
+     neo_dlnndr_in(tgyro_zero_dens_grad_flag) = 0
+  endif
+
   ! Rotation is always *on* in NEO.
   !
   ! COORDINATES: The signs of all rotation-related quantities below are 

--- a/tgyro/src/tgyro_read_input.f90
+++ b/tgyro/src/tgyro_read_input.f90
@@ -140,7 +140,8 @@ subroutine tgyro_read_input
   call tgyro_readbc_real(tgyro_ped_ratio)
   call tgyro_readbc_real(tgyro_ped_scale)
   call tgyro_readbc_real(tgyro_tglf_nn_max_error)
-  call tgyro_readbc_real(tgyro_quickfast_flag)
+  call tgyro_readbc_int(tgyro_quickfast_flag)
+  call tgyro_readbc_int(tgyro_zero_dens_grad_flag)
   ! ** END input read; ADD NEW PARAMETERS ABOVE HERE!!
   call tgyro_readbc_int(n_inst)
   !-------------------------------------------------------

--- a/tgyro/src/tgyro_tglf_map.f90
+++ b/tgyro/src/tgyro_tglf_map.f90
@@ -13,7 +13,7 @@ subroutine tgyro_tglf_map
   implicit none
 
   ! Local variables
-  integer :: i_ion,i0 
+  integer :: i_ion,i0
   integer :: harvest_err
   real :: q_abs
   real :: q_prime
@@ -88,6 +88,12 @@ subroutine tgyro_tglf_map
      tglf_rlts_in(i0) = r_min*dlntidr(i_ion,i_r)
      tglf_taus_in(i0) = ti(i_ion,i_r)/te(i_r)
   enddo
+  
+  ! Setting density gradient artificially to zero to compute D and v
+  if (tgyro_zero_dens_grad_flag /= 0) then
+     tglf_rlns_in(tgyro_zero_dens_grad_flag) = 0
+  endif
+  
   !----------------------------------------------------------------
   !   debye length/rhos   te in ev, rho_s in cm ne in 10^13/cm^3
   tglf_debye_in = 7.43D2*SQRT(te(i_r)/(ne(i_r)*1.D13))/rho_s(i_r)


### PR DESCRIPTION
Added tgyro_zero_dens_grad_flag to toggle zero density gradient for a specified species.

This is used for calculating the diffusion and pinch profile for the specified species from two TGYRO runs, where the first has tgyro_zero_dens_grad_flag = 0 and the second has tgyro_zero_dens_grad_flag = species_id.