### PR TITLE
Add CORI_KNL_ifort recipe files

### DIFF
--- a/platform/build/make.inc.CORI_KNL_ifort
+++ b/platform/build/make.inc.CORI_KNL_ifort
@@ -1,0 +1,31 @@
+#----------------------------------------------------------
+# Cray XC40 (cori.nersc.gov) 
+#
+# Cori SYSTEM INFO:
+# - Intel KNL
+# - 64 cores * 4 hyperthreads (assign hypethreads to numas)
+#----------------------------------------------------------
+
+IDENTITY="NERSC Cori KNL"
+CORES_PER_NODE=64
+NUMAS_PER_NODE=4
+
+# Compilers and flags
+FC     = ftn -gen-interfaces -module ${GACODE_ROOT}/modules
+F77    = ${FC}
+
+FOMP   = 
+FMATH  = -real-size 64
+FOPT   = -qopenmp -Ofast
+FDEBUG = -eD -Ktrap=fp -m 1
+
+# System math libraries
+LMATH = -lfftw3_threads -lfftw3f_threads -lfftw3 -lfftw3f 
+
+# NetCDF
+NETCDF = ${NETCDF_DIR}/lib/libnetcdff.a ${NETCDF_DIR}/lib/libnetcdf.a
+NETCDF_INC = ${NETCDF_DIR}/include
+
+# Archive 
+ARCH = ar cr
+

--- a/platform/env/env.CORI_KNL_ifort
+++ b/platform/env/env.CORI_KNL_ifort
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+module swap craype-haswell craype-mic-knl
+module load fftw/3.3.4.11
+module load python
+module load latex

--- a/platform/exec/exec.CORI_KNL_ifort
+++ b/platform/exec/exec.CORI_KNL_ifort
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash 
+#
+# SCRIPT:
+#  gyro.CORI_KNL
+#
+# FUNCTION:
+#  Parallel execution script
+#---------------------------------------------------
+
+simdir=${1}
+nmpi=${2}
+exec=${3}
+nomp=${4}
+numa=${5}
+mpinuma=${6}
+nidle=${7}
+
+# nmpi = MPI tasks
+# nomp = OpenMP threads per MPI task
+# numa = NUMAs active per node
+# mpinuma = MPI tasks per active NUMA 
+
+. $GACODE_ROOT/shared/bin/gacode_mpi_tool
+
+cd $simdir
+
+export OMP_NUM_THREADS=$nomp
+export OMP_PLACES=cores
+export OMP_STACKSIZE=32M
+echo "> srun --cpu_bind=cores -n $nmpi -c $(($CORES_PER_NODE/$mpinode*4)) $exec"
+srun --cpu_bind=cores -n $nmpi -c $(($CORES_PER_NODE/$mpinode*4)) $exec
+

--- a/platform/qsub/qsub.CORI_KNL_ifort
+++ b/platform/qsub/qsub.CORI_KNL_ifort
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "-queue: debug, regular"
+echo "  -qos: normal"
+
+# Default queue
+if [ "$QUEUE" == "null_queue" ] ; then
+   QUEUE=debug
+fi
+
+bfile=$SIMDIR/batch.src
+
+echo "#!/bin/bash -l" > $bfile
+echo "#SBATCH -J $LOCDIR" >> $bfile
+echo "#SBATCH -A $REPO" >> $bfile
+echo "#SBATCH -C knl,quad,cache" >> $bfile
+echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
+echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
+echo "#SBATCH -p $QUEUE" >> $bfile
+echo "#SBATCH --qos=$QOS" >> $bfile
+echo "#SBATCH -t $WALLTIME" >> $bfile
+echo "#SBATCH -N $nodes" >> $bfile
+echo "$CODE -e $LOCDIR -n $nmpi -nomp $nomp -numa $numa -mpinuma $mpinuma -p $SIMROOT" >> $bfile 


### PR DESCRIPTION
Add CORI_KNL_ifort recipe files, to build and run on Cory KNL nodes using the Intel fortran compiler