### PR TITLE
Change restart format

### DIFF
--- a/cgyro/bin/cgyro_parse.py
+++ b/cgyro/bin/cgyro_parse.py
@@ -75,6 +75,8 @@ x.add('NU_GLOBAL','0.4')
 x.add('PSYM_FLAG','0')
 x.add('PROFILE_SHEAR_FLAG','0')
 x.add('THETA_PLOT','1')
+x.add('MPIIO_STRIPE_FACTOR','32')
+x.add('MPIIO_NUM_FILES','1')
 
 x.add('RMIN','0.5')
 x.add('RMAJ','3.0')

--- a/cgyro/src/cgyro_globals.F90
+++ b/cgyro/src/cgyro_globals.F90
@@ -86,6 +86,9 @@ module cgyro_globals
   integer :: psym_flag
   integer :: profile_shear_flag
   integer :: theta_plot
+  integer :: mpiio_stripe_factor
+  integer :: mpiio_num_files
+  integer :: restart_format
   !
   ! Geometry input
   !
@@ -150,14 +153,18 @@ module cgyro_globals
   integer :: i_proc
   integer :: i_proc_1
   integer :: i_proc_2
+  integer :: i_proc_restart_io
   integer :: n_proc
   integer :: n_proc_1
   integer :: n_proc_2
+  integer :: n_proc_restart_io
   integer :: i_group_1
   integer :: i_group_2
+  integer :: i_group_restart_io
   integer :: CGYRO_COMM_WORLD
   integer :: NEW_COMM_1
   integer :: NEW_COMM_2
+  integer :: NEW_COMM_RESTART_IO
   integer :: nv1,nv2,nc1,nc2
   integer :: nsplit
   integer, dimension(:), allocatable :: recv_status
@@ -196,6 +203,7 @@ module cgyro_globals
   character(len=16) :: runfile_memory  = 'out.cgyro.memory'
   character(len=17) :: runfile_restart = 'out.cgyro.restart'
   character(len=13) :: runfile_restart_tag = 'out.cgyro.tag'
+  character(len=17) :: runfile_restart_tag_version = 'out.cgyro.res_ver'
   character(len=12) :: runfile_hb      = 'out.cgyro.hb'
   character(len=15) :: runfile_grids   = 'out.cgyro.grids'
   character(len=14) :: runfile_prec    = 'out.cgyro.prec'
@@ -215,6 +223,8 @@ module cgyro_globals
   ! Restart tags
   character(len=8) :: fmt='(I2.2)' 
   character(len=2), dimension(100) :: rtag
+  character(len=8) :: fmt_v2='(A,I2.2)'
+  character(len=6), dimension(100) :: rtag_v2
   !
   ! error checking
   integer :: error_status = 0
@@ -223,9 +233,10 @@ module cgyro_globals
   integer :: io_control
   integer :: signal
   integer :: restart_flag
-  integer :: n_chunk
-  character(len=2) :: mpiio_stripe='32'
-  real :: max_filesize
+  integer :: input_restart_format
+  character(len=3) :: mpiio_stripe_str
+  integer :: n_chunk      ! used in v1, for historical reasons
+  real :: max_filesize    ! used in v1, for historical reasons
   !
   ! Standard precision for IO (there are optionally reset to higher precision later)
   character(len=8)  :: fmtstr    ='(es11.4)'

--- a/cgyro/src/cgyro_init_h.f90
+++ b/cgyro/src/cgyro_init_h.f90
@@ -9,6 +9,10 @@ subroutine cgyro_init_h
   integer :: ir,it,is,ie,ix
   real :: arg, ang
 
+  ! set it to an invalid value by default
+  ! will be updated if there is a restart file read
+  input_restart_format = 0
+
   !---------------------------------------------------------------------
   ! Check to see if we have restart data available
   !

--- a/cgyro/src/cgyro_read_input.f90
+++ b/cgyro/src/cgyro_read_input.f90
@@ -80,6 +80,8 @@ subroutine cgyro_read_input
   call cgyro_readbc_int(psym_flag)
   call cgyro_readbc_int(profile_shear_flag)
   call cgyro_readbc_int(theta_plot)
+  call cgyro_readbc_int(mpiio_stripe_factor)
+  call cgyro_readbc_int(mpiio_num_files)
 
   call cgyro_readbc_real(rmin)
   call cgyro_readbc_real(rmaj)

--- a/cgyro/src/cgyro_read_restart.f90
+++ b/cgyro/src/cgyro_read_restart.f90
@@ -12,10 +12,214 @@ subroutine cgyro_read_restart
   use cgyro_globals
   use cgyro_io
 
+  !---------------------------------------------------------
+  ! Read restart parameters from ASCII file.
+  !
+  if (i_proc == 0) then
+
+     open(unit=io,&
+          file=trim(path)//runfile_restart_tag,&
+          status='old')
+
+     read(io,*) i_current
+     read(io,fmtstr) t_current
+     close(io)
+
+     open(unit=io,&
+          file=trim(path)//runfile_restart_tag_version,&
+          iostat=i_err,&
+          status='old')
+
+     if (i_err==0) then
+          read(io,*) input_restart_format
+          close(io)
+          call cgyro_info('Restart version found.')
+     else
+          ! v1 had no version file
+          input_restart_format = 1
+          call cgyro_info('Restart version not found. Assuming v1.')
+     endif
+
+  endif
+
+  ! Broadcast to all cores.
+
+  call MPI_BCAST(i_current,&
+       1,MPI_INTEGER,0,CGYRO_COMM_WORLD,i_err)
+
+  call MPI_BCAST(t_current,&
+       1,MPI_DOUBLE_PRECISION,0,CGYRO_COMM_WORLD,i_err)
+
+  call MPI_BCAST(input_restart_format,&
+       1,MPI_INTEGER,0,CGYRO_COMM_WORLD,i_err)
+
+  !---------------------------------------------------------
+
+  if (input_restart_format==2) then
+    if (mpiio_num_files==1) then
+       call cgyro_read_restart_one
+    else
+       call cgyro_read_restart_v2
+    endif
+  elseif (input_restart_format==1) then
+    if (n_chunk==1) then
+       call cgyro_read_restart_one
+    else
+       call cgyro_read_restart_v1
+    endif
+  else
+    call cgyro_error('ERROR: (CGYRO) Invalid restart_format found.')
+  endif
+
+end subroutine cgyro_read_restart
+
+subroutine cgyro_read_restart_one
+
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
   !---------------------------------------------------
   implicit none
   !
-  ! Required for MPI-IO: 
+  ! Required for MPI-IO:
+  !
+  integer :: filemode
+  integer :: finfo
+  integer :: fhv
+  integer :: fstatus(MPI_STATUS_SIZE)
+  integer(kind=MPI_OFFSET_KIND) :: disp
+  integer(kind=MPI_OFFSET_KIND) :: offset1
+  !---------------------------------------------------
+
+  filemode = MPI_MODE_RDONLY
+  disp     = 0
+
+  offset1 = size(h_x,kind=MPI_OFFSET_KIND)*i_proc
+  if (offset1<0) then
+     call cgyro_error('ERROR: (CGYRO) overflow detected in cgyro_read_restart_one')
+     return
+  endif
+
+  call MPI_INFO_CREATE(finfo,i_err)
+
+  call MPI_FILE_OPEN(CGYRO_COMM_WORLD,&
+          trim(path)//runfile_restart,&
+          filemode,&
+          finfo,&
+          fhv,&
+          i_err)
+  if (i_err /= 0) then
+     call cgyro_error('ERROR: (CGYRO) MPI_FILE_OPEN in cgyro_read_restart_one failed')
+     return
+  endif
+
+  call MPI_FILE_SET_VIEW(fhv,&
+          disp,&
+          MPI_COMPLEX16,&
+          MPI_COMPLEX16,&
+          'native',&
+          finfo,&
+          i_err)
+
+  call MPI_FILE_READ_AT(fhv,&
+          offset1,&
+          h_x,&
+          size(h_x),&
+          MPI_COMPLEX16,&
+          fstatus,&
+          i_err)
+  if (i_err /= 0) then
+     call cgyro_error('ERROR: (CGYRO) MPI_FILE_READ_AT in cgyro_read_restart_one failed')
+     return
+  endif
+
+  call MPI_FILE_CLOSE(fhv,i_err)
+  call MPI_INFO_FREE(finfo,i_err)
+
+end subroutine cgyro_read_restart_one
+
+subroutine cgyro_read_restart_v2
+
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
+  !---------------------------------------------------
+  implicit none
+  !
+  ! Required for MPI-IO:
+  !
+  integer :: filemode
+  integer :: finfo
+  integer :: fhv
+  integer :: fstatus(MPI_STATUS_SIZE)
+  integer(kind=MPI_OFFSET_KIND) :: disp
+  integer(kind=MPI_OFFSET_KIND) :: offset1
+  !---------------------------------------------------
+
+  filemode = MPI_MODE_RDONLY
+  disp     = 0
+
+  offset1 = size(h_x,kind=MPI_OFFSET_KIND)*i_proc_restart_io
+
+  if (offset1<0) then
+     call cgyro_error('ERROR: (CGYRO) overflow detected in cgyro_read_restart_v2')
+     return
+  endif
+
+  call MPI_INFO_CREATE(finfo,i_err)
+
+  call MPI_FILE_OPEN(NEW_COMM_RESTART_IO,&
+          trim(path)//runfile_restart//rtag_v2(i_group_restart_io),&
+          filemode,&
+          finfo,&
+          fhv,&
+          i_err)
+  if (i_err /= 0) then
+     call cgyro_error('ERROR: (CGYRO) MPI_FILE_OPEN in cgyro_read_restart_v2 failed')
+     return
+  endif
+
+  call MPI_FILE_SET_VIEW(fhv,&
+          disp,&
+          MPI_COMPLEX16,&
+          MPI_COMPLEX16,&
+          'native',&
+          finfo,&
+          i_err)
+
+  call MPI_FILE_READ_AT(fhv,&
+          offset1,&
+          h_x,&
+          size(h_x),&
+          MPI_COMPLEX16,&
+          fstatus,&
+          i_err)
+  if (i_err /= 0) then
+     call cgyro_error('ERROR: (CGYRO) MPI_FILE_READ_AT in cgyro_read_restart_v2 failed')
+     return
+  endif
+
+  call MPI_FILE_CLOSE(fhv,i_err)
+  call MPI_INFO_FREE(finfo,i_err)
+
+end subroutine cgyro_read_restart_v2
+
+! ---------------------------------------------------
+! This routine is provided for backwards compatibility
+! Eventually we should phase it out
+
+subroutine cgyro_read_restart_v1
+
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
+  !---------------------------------------------------
+  implicit none
+  !
+  ! Required for MPI-IO:
   !
   integer :: filemode
   integer :: finfo
@@ -30,44 +234,23 @@ subroutine cgyro_read_restart
   complex, dimension(:,:), allocatable :: h_chunk
   !---------------------------------------------------
 
-  !---------------------------------------------------------
-  ! Read restart parameters from ASCII file.
-  !
-  if (i_proc == 0) then
-
-     open(unit=io,&
-          file=trim(path)//runfile_restart_tag,&
-          status='old')
-
-     read(io,*) i_current
-     read(io,fmtstr) t_current
-     close(io)
-
-  endif
-
-  ! Broadcast to all cores.
-
-  call MPI_BCAST(i_current,&
-       1,MPI_INTEGER,0,CGYRO_COMM_WORLD,i_err)
-
-  call MPI_BCAST(t_current,&
-       1,MPI_DOUBLE_PRECISION,0,CGYRO_COMM_WORLD,i_err)
-  !---------------------------------------------------------
-
-  filemode = IOR(MPI_MODE_RDWR,MPI_MODE_CREATE)
+  filemode = MPI_MODE_RDONLY
   disp     = 0
 
   n_loc = nc/n_chunk
   n_remain = nc-n_loc*n_chunk
   allocate(h_chunk(n_loc+n_remain,nv_loc))
 
-  offset1 = size(h_chunk,kind=8)*i_proc
+  offset1 = size(h_chunk,kind=MPI_OFFSET_KIND)*i_proc
   
+  if (offset1<0) then
+     call cgyro_error('ERROR: (CGYRO) overflow detected in cgyro_read_restart_v1')
+     return
+  endif
+
   do j=1,n_chunk
 
      call MPI_INFO_CREATE(finfo,i_err)
-
-     call MPI_INFO_SET(finfo,"striping_factor",mpiio_stripe,i_err)
 
      call MPI_FILE_OPEN(CGYRO_COMM_WORLD,&
           trim(path)//runfile_restart//rtag(j),&
@@ -75,6 +258,10 @@ subroutine cgyro_read_restart
           finfo,&
           fhv,&
           i_err)
+     if (i_err /= 0) then
+        call cgyro_error('ERROR: (CGYRO) MPI_FILE_OPEN in cgyro_read_restart_v1 failed')
+        return
+     endif
 
      call MPI_FILE_SET_VIEW(fhv,&
           disp,&
@@ -91,6 +278,10 @@ subroutine cgyro_read_restart
           MPI_COMPLEX16,&
           fstatus,&
           i_err)
+     if (i_err /= 0) then
+        call cgyro_error('ERROR: (CGYRO) MPI_FILE_READ_AT in cgyro_read_restart_v1 failed')
+        return
+     endif
 
      i1 = 1+(j-1)*n_loc
      i2 = j*n_loc
@@ -102,9 +293,10 @@ subroutine cgyro_read_restart
      h_x(i1:i2,:) = h_chunk(1:n_loc,:)
 
      call MPI_FILE_CLOSE(fhv,i_err)
+     call MPI_INFO_FREE(finfo,i_err)
 
   enddo
 
   deallocate(h_chunk)
 
-end subroutine cgyro_read_restart
+end subroutine cgyro_read_restart_v1

--- a/cgyro/src/cgyro_write_restart.f90
+++ b/cgyro/src/cgyro_write_restart.f90
@@ -12,10 +12,241 @@ subroutine cgyro_write_restart
   use cgyro_globals
   use cgyro_io
 
+  ! Print this data on restart steps only; otherwise exit now
+  if (mod(i_time,restart_step*print_step) /= 0) return
+
+  if (restart_format==2) then
+    if (mpiio_num_files==1) then
+       call cgyro_write_restart_one
+    else
+       call cgyro_write_restart_v2
+    endif
+  elseif (restart_format==1) then
+    if (n_chunk==1) then
+       call cgyro_write_restart_one
+    else
+       call cgyro_write_restart_v1
+    endif
+  else
+    call cgyro_error('ERROR: (CGYRO) Invalid restart_format found.')
+  endif
+end subroutine cgyro_write_restart
+
+! Dump restart parameters to ASCII file.
+subroutine cgyro_write_restart_tag
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
+  open(unit=io,file=trim(path)//runfile_restart_tag,status='replace')
+  write(io,*) i_current
+  write(io,fmtstr) t_current
+  close(io)
+
+  if (restart_format/=1) then
+     open(unit=io,file=trim(path)//runfile_restart_tag_version,status='replace')
+     write(io,*) restart_format
+     close(io)
+  endif
+
+end subroutine cgyro_write_restart_tag
+
+subroutine cgyro_write_restart_one
+
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
   !----------------------------------------------
   implicit none
   !
   ! Required for MPI-IO: 
+  !
+  integer :: filemode
+  integer :: finfo
+  integer :: fhv
+  integer :: fstatus(MPI_STATUS_SIZE)
+  integer(kind=MPI_OFFSET_KIND) :: disp
+  integer(kind=MPI_OFFSET_KIND) :: offset1
+  !----------------------------------------------
+
+
+  !-----------------------------------------------
+  ! Dump h and blending coefficients:
+  !
+  filemode = IOR(MPI_MODE_WRONLY,MPI_MODE_CREATE)
+  disp     = 0
+
+  offset1 = size(h_x,kind=MPI_OFFSET_KIND)*i_proc
+  if (offset1<0) then
+     call cgyro_error('ERROR: (CGYRO) overflow detected in cgyro_write_restart_one')
+     return
+  endif
+
+  ! TODO Error handling
+  call MPI_INFO_CREATE(finfo,i_err)
+
+  call MPI_INFO_SET(finfo,"striping_factor",mpiio_stripe_str,i_err)
+
+  call MPI_FILE_OPEN(CGYRO_COMM_WORLD,&
+          trim(path)//runfile_restart,&
+          filemode,&
+          finfo,&
+          fhv,&
+          i_err)
+
+  call MPI_FILE_SET_VIEW(fhv,&
+          disp,&
+          MPI_COMPLEX16,&
+          MPI_COMPLEX16,&
+          'native',&
+          finfo,&
+          i_err)
+
+  call MPI_FILE_WRITE_AT(fhv,&
+          offset1,&
+          h_x,&
+          size(h_x),&
+          MPI_COMPLEX16,&
+          fstatus,&
+          i_err)
+  if (i_err /= 0) then
+     call cgyro_error('ERROR: (CGYRO) MPI_FILE_WRITE_AT in cgyro_write_restart_one failed')
+     return
+  endif
+
+  call MPI_FILE_SYNC(fhv,i_err)
+  call MPI_FILE_CLOSE(fhv,i_err)
+  call MPI_INFO_FREE(finfo,i_err)
+
+  !---------------------------------------------------------
+  ! Dump restart parameters to ASCII file.
+  !
+  if (i_proc == 0) then
+     call cgyro_write_restart_tag
+  endif
+  !---------------------------------------------------------
+
+end subroutine cgyro_write_restart_one
+
+
+subroutine cgyro_write_restart_v2
+
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
+  !----------------------------------------------
+  implicit none
+  !
+  ! Required for MPI-IO:
+  !
+  integer :: filemode
+  integer :: finfo
+  integer :: fhv
+  integer :: fstatus(MPI_STATUS_SIZE)
+  integer(kind=MPI_OFFSET_KIND) :: disp
+  integer(kind=MPI_OFFSET_KIND) :: offset1
+  !----------------------------------------------
+
+
+  !-----------------------------------------------
+  ! Dump h and blending coefficients:
+  !
+  filemode = IOR(MPI_MODE_WRONLY,MPI_MODE_CREATE)
+  disp     = 0
+
+  offset1 = size(h_x,kind=MPI_OFFSET_KIND)*i_proc_restart_io
+
+  if (offset1<0) then
+     call cgyro_error('ERROR: (CGYRO) overflow detected in cgyro_write_restart_v2')
+     return
+  endif
+
+  call MPI_INFO_CREATE(finfo,i_err)
+
+  call MPI_INFO_SET(finfo,"striping_factor",mpiio_stripe_str,i_err)
+
+  call MPI_FILE_OPEN(NEW_COMM_RESTART_IO,&
+          trim(path)//runfile_restart//rtag_v2(i_group_restart_io),&
+          filemode,&
+          finfo,&
+          fhv,&
+          i_err)
+
+  call MPI_FILE_SET_VIEW(fhv,&
+          disp,&
+          MPI_COMPLEX16,&
+          MPI_COMPLEX16,&
+          'native',&
+          finfo,&
+          i_err)
+
+  call MPI_FILE_WRITE_AT(fhv,&
+          offset1,&
+          h_x,&
+          size(h_x),&
+          MPI_COMPLEX16,&
+          fstatus,&
+          i_err)
+  if (i_err /= 0) then
+     call cgyro_error('ERROR: (CGYRO) MPI_FILE_WRITE_AT in cgyro_write_restart_v2 failed')
+     return
+  endif
+
+  call MPI_FILE_SYNC(fhv,i_err)
+  call MPI_FILE_CLOSE(fhv,i_err)
+  call MPI_INFO_FREE(finfo,i_err)
+
+  !---------------------------------------------------------
+  ! Wait for all groups to finish
+  call MPI_Barrier(CGYRO_COMM_WORLD,i_err)
+
+  !---------------------------------------------------------
+  ! Dump restart parameters to ASCII file.
+  !
+  if (i_proc == 0) then
+     call cgyro_write_restart_tag
+
+     ! remove ambiguity
+     if (input_restart_format==1) then
+        call cgyro_del_restart_v1
+        input_restart_format=0 ! avoid doing it in the next iteration
+     endif
+  endif
+  !---------------------------------------------------------
+
+end subroutine cgyro_write_restart_v2
+
+subroutine cgyro_del_restart_v2
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
+  integer :: j
+  integer :: stat
+
+  do j=1,mpiio_num_files
+    open(unit=io,file=trim(path)//runfile_restart//rtag_v2(j),iostat=stat,status='old')
+    if (stat == 0) close(io, status='delete')
+  enddo
+end subroutine cgyro_del_restart_v2
+
+! --------------------------------------------------------------
+! cgyro_write_restart_v1 is deprecated (As of Aug 2017)
+! Leaving in the code for now for testing/debugging reasons
+! Should be removed in the near future
+
+subroutine cgyro_write_restart_v1
+
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
+  !----------------------------------------------
+  implicit none
+  !
+  ! Required for MPI-IO:
   !
   integer :: filemode
   integer :: finfo
@@ -30,26 +261,28 @@ subroutine cgyro_write_restart
   complex, dimension(:,:), allocatable :: h_chunk
   !----------------------------------------------
 
-  ! Print this data on restart steps only; otherwise exit now
-  if (mod(i_time,restart_step*print_step) /= 0) return
-
   !-----------------------------------------------
   ! Dump h and blending coefficients:
   !
-  filemode = IOR(MPI_MODE_RDWR,MPI_MODE_CREATE)
+  filemode = IOR(MPI_MODE_WRONLY,MPI_MODE_CREATE)
   disp     = 0
 
   n_loc = nc/n_chunk
   n_remain = nc-n_loc*n_chunk
   allocate(h_chunk(n_loc+n_remain,nv_loc))
 
-  offset1 = size(h_chunk,kind=8)*i_proc
+  offset1 = size(h_chunk,kind=MPI_OFFSET_KIND)*i_proc
+
+  if (offset1<0) then
+     call cgyro_error('ERROR: (CGYRO) overflow detected in cgyro_write_restart_v1')
+     return
+  endif
 
   do j=1,n_chunk
 
      call MPI_INFO_CREATE(finfo,i_err)
 
-     call MPI_INFO_SET(finfo,"striping_factor",mpiio_stripe,i_err)
+     call MPI_INFO_SET(finfo,"striping_factor",mpiio_stripe_str,i_err)
 
      call MPI_FILE_OPEN(CGYRO_COMM_WORLD,&
           trim(path)//runfile_restart//rtag(j),&
@@ -82,9 +315,14 @@ subroutine cgyro_write_restart
           MPI_COMPLEX16,&
           fstatus,&
           i_err)
+     if (i_err /= 0) then
+       call cgyro_error('ERROR: (CGYRO) MPI_FILE_WRITE_AT in cgyro_write_restart_v1 failed')
+        return
+     endif
 
      call MPI_FILE_SYNC(fhv,i_err)
      call MPI_FILE_CLOSE(fhv,i_err)
+     call MPI_INFO_FREE(finfo,i_err)
 
   enddo
 
@@ -94,13 +332,29 @@ subroutine cgyro_write_restart
   ! Dump restart parameters to ASCII file.
   !
   if (i_proc == 0) then
+     call cgyro_write_restart_tag
 
-     open(unit=io,file=trim(path)//runfile_restart_tag,status='replace')
-     write(io,*) i_current
-     write(io,fmtstr) t_current
-     close(io)
-
+     ! remove ambiguity
+     if (input_restart_format==2) then
+        call cgyro_del_restart_v2
+        input_restart_format=0 ! avoid doing it in the next iteration
+     endif
   endif
   !---------------------------------------------------------
 
-end subroutine cgyro_write_restart
+end subroutine cgyro_write_restart_v1
+
+subroutine cgyro_del_restart_v1
+  use mpi
+  use cgyro_globals
+  use cgyro_io
+
+  integer :: j
+  integer :: stat
+
+  do j=1,n_chunk
+    open(unit=io,file=trim(path)//runfile_restart//rtag(j),iostat=stat,status='old')
+    if (stat == 0) close(io, status='delete')
+  enddo
+end subroutine cgyro_del_restart_v1
+


### PR DESCRIPTION
Change the default restart file format, to be more efficient.
Add MPIIO_STRIPE_FACTOR and MPIIO_NUM_FILES input parameters.
Contains backwards compatibility handling code.