### PR TITLE
TGYRO: Add new TGYRO_INPUT_FUSION_SCALE parameter

### DIFF
--- a/tgyro/bin/tgyro_parse.py
+++ b/tgyro/bin/tgyro_parse.py
@@ -112,6 +112,7 @@ x.add('TGYRO_TGLF_NN_MAX_ERROR','-1')
 x.add('TGYRO_QUICKFAST_FLAG','0')
 x.add('TGYRO_ZERO_DENS_GRAD_FLAG','0')
 x.add('TGYRO_RESIDUAL_TOL','0.0')
+x.add('TGYRO_INPUT_FUSION_SCALE','1.0')
 
 # Deprecated parameters
 x.dep('LOC_N_FEEDBACK','new parameter is LOC_NE_FEEDBACK_FLAG')

--- a/tgyro/src/tgyro_globals.f90
+++ b/tgyro/src/tgyro_globals.f90
@@ -326,6 +326,7 @@ module tgyro_globals
   integer :: tgyro_quickfast_flag
   integer :: tgyro_zero_dens_grad_flag
   real :: tgyro_residual_tol
+  real :: tgyro_input_fusion_scale
   !
   ! Iteration variables (global)
   !

--- a/tgyro/src/tgyro_read_input.f90
+++ b/tgyro/src/tgyro_read_input.f90
@@ -143,6 +143,7 @@ subroutine tgyro_read_input
   call tgyro_readbc_int(tgyro_quickfast_flag)
   call tgyro_readbc_int(tgyro_zero_dens_grad_flag)
   call tgyro_readbc_real(tgyro_residual_tol)
+  call tgyro_readbc_real(tgyro_input_fusion_scale)
   ! ** END input read; ADD NEW PARAMETERS ABOVE HERE!!
   call tgyro_readbc_int(n_inst)
   !-------------------------------------------------------

--- a/tgyro/src/tgyro_source.f90
+++ b/tgyro/src/tgyro_source.f90
@@ -41,7 +41,7 @@ subroutine tgyro_source
         endif
         ! Alpha particle source and power 
         ! - Can use 'hively' or 'bosch' formulae.
-        sn_alpha(i) = n_d*n_t*sigv(ti(1,i)/1e3,'bosch')
+        sn_alpha(i) = n_d*n_t*sigv(ti(1,i)/1e3,'bosch') * tgyro_input_fusion_scale
 
         s_alpha      = sn_alpha(i)*e_alpha
         s_alpha_i(i) = s_alpha*frac_ai(i)

--- a/tgyro/src/tgyro_write_input.f90
+++ b/tgyro/src/tgyro_write_input.f90
@@ -543,6 +543,14 @@ subroutine tgyro_write_input
 
      write(1,*)'-----------------------------------------------------------------'
 
+     !--------------------------------------------------------
+     write(1,*)
+     write(1,*) 'Fusion reactivity rescaling factor'
+     write(1,*) 
+     write(1,20) 'TGYRO_INPUT_FUSION_SCALE',tgyro_input_fusion_scale
+
+     write(1,*)'-----------------------------------------------------------------'
+
      close(1)
 
   endif


### PR DESCRIPTION
The point of the parameter is to mock up what would happen if the DT fusion cross section was modified, such as due to spin polarization of the DT fuel

This parameter can range from 0.5 to 1.5 (polarization antiparallel aligned to polarization aligned) for spin polarized fuel, since it multiplies the thermal DT fusion cross section.