### PR TITLE
NEO: Change error checking for max number of species from 6 to 11

### DIFF
--- a/neo/src/neo_check.f90
+++ b/neo/src/neo_check.f90
@@ -19,7 +19,7 @@ subroutine neo_check
      return
   endif
   !
-  if (n_species > 6) then
+  if (n_species > 11) then
      call neo_error('ERROR: (NEO) max n_species is 6')
      return
   endif


### PR DESCRIPTION
This changes the check on the max number of species to be consistent with what is indicated by the comments and array size declarations in `neo_globals.f90`.  I have not yet rerun the TGYRO case that led to finding this, but thought I would open the discussion, in case there was some reason for keeping the max of 6.