### PR TITLE
WIP: Changed relaxation of simplerelax to harvest tglf

### DIFF
--- a/tgyro/src/tgyro_iteration_simplerelax.f90
+++ b/tgyro/src/tgyro_iteration_simplerelax.f90
@@ -87,7 +87,7 @@ subroutine tgyro_iteration_simplerelax
 
         if (loc_te_feedback_flag == 1) then
            p = p+1
-           simpledz = relax(p)*(f_vec(p) - g_vec(p))
+           simpledz = relax(p)*(f_vec(p) - g_vec(p))/sqrt(f_vec(p)**2+g_vec(p)**2)
            if (abs(simpledz) > loc_dx_max) then
               simpledz = loc_dx_max*(simpledz/abs(simpledz))
            endif
@@ -97,7 +97,7 @@ subroutine tgyro_iteration_simplerelax
 
         if (loc_er_feedback_flag == 1) then
            p = p+1
-           simpledz = -relax(p)*(f_vec(p) - g_vec(p))           
+           simpledz = -relax(p)*(f_vec(p) - g_vec(p))/sqrt(f_vec(p)**2+g_vec(p)**2)           
            if (abs(simpledz) > loc_dx_max) then
               simpledz = loc_dx_max*(simpledz/abs(simpledz))
            endif
@@ -107,7 +107,7 @@ subroutine tgyro_iteration_simplerelax
 
         if (evo_e(0) == 1) then
            p = p+1
-           simpledz = relax(p)*(f_vec(p) - g_vec(p))             
+           simpledz = relax(p)*(f_vec(p) - g_vec(p))/sqrt(f_vec(p)**2+g_vec(p)**2)             
            if (abs(simpledz) > loc_dx_max) then
               simpledz = loc_dx_max*(simpledz/abs(simpledz))
            endif
@@ -118,7 +118,7 @@ subroutine tgyro_iteration_simplerelax
         do i_ion=1,loc_n_ion
            if (evo_e(i_ion) == 1) then
               p = p+1 
-              simpledz = relax(p)*(f_vec(p) - g_vec(p))
+              simpledz = relax(p)*(f_vec(p) - g_vec(p))/sqrt(f_vec(p)**2+g_vec(p)**2)
               if (abs(simpledz) > loc_dx_max) then
                   simpledz = loc_dx_max*(simpledz/abs(simpledz))
               endif


### PR DESCRIPTION
👍 @jmcclena if I understand correctly looking at 74abca2  and https://github.com/gafusion/gacode/compare/simple_for_harvest#commitcomment-29540473:
* Original method --> `dz=relax/abs(g0)*(f-g)`
* New method (blue curve)--> `dz=relax*(f-g)/sqrt(f^2+g^2)`
* New method (green curve)--> `dz=relax/sqrt(f0^2+g0^2)*(f-g)`

and we need to change the iteration scheme also for the other channels (not only ion temperature)