### PR TITLE
Add out.cgyro.startups

### DIFF
--- a/cgyro/src/cgyro_globals.F90
+++ b/cgyro/src/cgyro_globals.F90
@@ -217,6 +217,7 @@ module cgyro_globals
   character(len=14) :: runfile_prec    = 'out.cgyro.prec'
   character(len=14) :: runfile_time    = 'out.cgyro.time'
   character(len=16) :: runfile_timers  = 'out.cgyro.timing'
+  character(len=18) :: runfile_startups= 'out.cgyro.startups'
   character(len=14) :: runfile_freq    = 'out.cgyro.freq'
   character(len=14) :: binfile_freq    = 'bin.cgyro.freq'
   character(len=12) :: binfile_hb      = 'bin.cgyro.hb'


### PR DESCRIPTION
Add startup and checkpoint timers.
These go into a new file, named
out.cgyro.startups

Unlike many other files, it is always appended to, so one can followed the evolution of the simulation across restarts.

Here is an example output:
sfiligoi@cori03:nl01_256_1> cat out.cgyro.startups
2018/08/23 16:17:19.677-0700 [STARTED] Initialization time:  1.779E+01 (mpi init:  8.942E-01)
2018/08/23 16:18:21.050-0700 [CHECKPOINTED] Checkpoint time:  6.269E-01
2018/08/23 16:19:29.437-0700 [CHECKPOINTED] Checkpoint time:  8.374E-01
2018/08/23 16:19:59.148-0700 [EXIT] After  1.773E+02
2018/08/23 16:27:03.909-0700 [READ CHECKPOINT] Restart checkpoint read time:  1.961E-01
2018/08/23 16:27:16.132-0700 [STARTED] Initialization time:  1.806E+01 (mpi init:  1.175E+00)
2018/08/23 16:28:20.003-0700 [CHECKPOINTED] Checkpoint time:  6.048E-01
2018/08/23 16:29:21.171-0700 [CHECKPOINTED] Checkpoint time:  9.335E-01
2018/08/23 16:29:52.059-0700 [EXIT] After  1.740E+02
