### PR TITLE
Fix new restart format header

### DIFF
--- a/cgyro/src/cgyro_read_restart.F90
+++ b/cgyro/src/cgyro_read_restart.F90
@@ -187,9 +187,15 @@ subroutine cgyro_read_restart_verify
   integer :: magic, version, recid
   integer :: t_n_theta,t_n_radial,t_n_species,t_n_xi,t_n_energy,t_n_toroidal
 
+  ! Different compilers have a different semantics for RECL... must use inquire
+  integer :: reclen
+  integer, dimension(1) :: recltest
+
+  inquire(iolength=reclen) recltest
+
   open(unit=io,&
        file=trim(path)//runfile_restart,&
-       status='old',access='DIRECT',RECL=4,ACTION='READ')
+       status='old',access='DIRECT',RECL=reclen,ACTION='READ')
 
   recid = 1
 

--- a/cgyro/src/cgyro_write_restart.F90
+++ b/cgyro/src/cgyro_write_restart.F90
@@ -178,9 +178,15 @@ subroutine cgyro_write_restart_header_part
   integer, parameter :: version = 2
   integer :: recid
 
+  ! Different compilers have a different semantics for RECL... must use inquire
+  integer :: reclen
+  integer, dimension(1) :: recltest
+
+  inquire(iolength=reclen) recltest
+
   open(unit=io,&
        file=trim(path)//runfile_restart//".part",&
-       status='old',access='DIRECT',RECL=4)
+       status='old',access='DIRECT',RECL=reclen)
 
   recid = 1
   write(io,REC=recid) restart_magic


### PR DESCRIPTION
Fix header creation for then new restart format.
Was not working for all compilers; in particular it was broken for ifort.