### PR TITLE
Bugfix:Allow absolute reference to input.gacode file

### DIFF
--- a/profiles_gen/bin/gacode_type_autodetect
+++ b/profiles_gen/bin/gacode_type_autodetect
@@ -10,18 +10,18 @@
 #  ITERDBNC    (netCDF iterdb)
 #  SWIM        (plasmastate)
 #  PFILE       (peqdsk)
-#  CORSICA  
+#  CORSICA
 #  GFILE       (geqdsk equilibrium data)
 #  DSKGATO_OLD (old-type dskgato flux-surface data)
 #  DSKGATO_NEW (new-type dskgato flux-surface data)
 #--------------------------------------------
 
-if [ "$1" == "input.gacode" ] ; then
-    echo "GACODE" 
+if [ "$(basename $1)" == "input.gacode" ] ; then
+    echo "GACODE"
     exit 0
 fi
 if [ "$1" == "input.profiles" ] ; then
-    echo "LEGACY" 
+    echo "LEGACY"
     exit 0
 fi
 if [ "$1" == "UFILE" ] ; then
@@ -70,8 +70,8 @@ if [[ "$x" == "NetCDF Data Format data" ]] ; then
    y=`ncdump -c $1 | grep -c dim_nrho_eq`
    if [[ $y -gt 0 ]] ; then
       echo "SWIM"
-   fi      
-   exit 0 
+   fi
+   exit 0
 
 else
    # pfile, gfile, iterdb text
@@ -84,48 +84,47 @@ else
 
 #   y=`grep -c BT_EXP $1`
 #   if [[ $y -gt 0 ]] ; then
-#      echo "GACODE" 
+#      echo "GACODE"
 #      exit 0
-#   fi 
+#   fi
 
    y=`grep -c cxareao $1`
    if [[ $y -gt 0 ]] ; then
-      echo "ITERDB" 
+      echo "ITERDB"
       exit 0
-   fi 
+   fi
 
    y=`grep -c CORSICA $1`
    if [[ $y -gt 0 ]] ; then
-      echo "CORSICA" 
+      echo "CORSICA"
       exit 0
-   fi 
+   fi
 
    # If we get to this point, we are dealing with equilibrium data
    y=`sed -n '2p' < $1 | grep -o E | wc -l`
    if [[ $y -eq 5 ]] ; then
-      echo "GFILE" 
+      echo "GFILE"
       exit 0
    fi
-   
+
    if [[ $y -eq 4 ]] ; then
-      echo "DSKGATO_OLD" 
+      echo "DSKGATO_OLD"
       exit 0
-   fi 
+   fi
 
    y=`sed -n '4p' < $1 | grep -o E | wc -l`
    if [[ $y -eq 4 ]] ; then
-      echo "DSKGATO_NEW" 
+      echo "DSKGATO_NEW"
       exit 0
-   fi 
+   fi
 
    # Added a new gfile test
    y=`head -1 $1 | grep -o E | wc -l`
    if [[ $y -eq 1 ]] ; then
-      echo "GFILE" 
+      echo "GFILE"
       exit 0
-   fi 
-  
-   echo "UNKNOWN" 
+   fi
+
+   echo "UNKNOWN"
    exit 1;
 fi
-

--- a/profiles_gen/src/prgen_read_inputgacode.f90
+++ b/profiles_gen/src/prgen_read_inputgacode.f90
@@ -13,10 +13,10 @@ subroutine prgen_read_inputgacode
   implicit none
 
   expro_ctrl_quasineutral_flag = 0
-  expro_ctrl_numeq_flag = 0 
-  
-  call expro_read('input.gacode')
-  
+  expro_ctrl_numeq_flag = 0
+
+  call expro_read(file_state)
+
   nx = expro_n_exp
 
   call prgen_allocate
@@ -24,5 +24,5 @@ subroutine prgen_read_inputgacode
   ! Needed for diagnostic printing
   rmin(:) = expro_rmin(:)
   rmaj(:) = expro_rmaj(:)
-   
+
 end subroutine prgen_read_inputgacode


### PR DESCRIPTION
It is possible to put in an absolute reference to a statefile, so I figured it was OK for an input.gacode file.  If there is something subtle I am missing about needing `input.gacode` in the directory where `profiles_gen` is run, then something more needs to be done.  This is not needed for OMFIT.