### PR TITLE
Add rho definition from expro_rho per suggestion of @JisungKang in #200

### DIFF
--- a/profiles_gen/src/prgen_read_inputgacode.f90
+++ b/profiles_gen/src/prgen_read_inputgacode.f90
@@ -25,4 +25,9 @@ subroutine prgen_read_inputgacode
   rmin(:) = expro_rmin(:)
   rmaj(:) = expro_rmaj(:)
 
+  ! Needed for gfile parsing
+  rho(:) = expro_rho(:)
+
+  ! Other prgen_globals may need to be defined here
+
 end subroutine prgen_read_inputgacode

--- a/profiles_gen/src/prgen_read_omfit.f90
+++ b/profiles_gen/src/prgen_read_omfit.f90
@@ -59,11 +59,10 @@ subroutine prgen_read_omfit
   call prgen_get_chi(npsi,efit_q,efit_psi,efit_rho,torfluxa)
 
   if (format_type /= 3) then
-     ! We have rho on statefile grid
-     rho = expro_rho
+     ! We have rho on input grid from prgen_globals
      call cub_spline(efit_rho,efit_psi,npsi,rho,dpsi,nx)
   else
-     ! We have psinorm on statefile grid (peqdsk)
+     ! We have psinorm on input grid (peqdsk) from prgen_globals
      dpsi = dpsi*dpsi_efit
      call cub_spline(efit_psi,efit_q,npsi,dpsi,q,nx)
      call prgen_get_chi(nx,q,dpsi,rho,torfluxa)


### PR DESCRIPTION
I don't know if this is the correct fix, or if some other variable should be using `expro_rho` instead of `rho`.