### PR TITLE
platform:GFORTRAN_OSX_MACPORTS gcc-10 compilation fix

### DIFF
--- a/platform/build/make.inc.GFORTRAN_OSX_MACPORTS
+++ b/platform/build/make.inc.GFORTRAN_OSX_MACPORTS
@@ -16,7 +16,7 @@ MF90 = mpif90-openmpi-mp
 #
 
 FC  = ${MF90} -std=f2008 -fall-intrinsics -I$(GACODE_ROOT)/modules -J$(GACODE_ROOT)/modules -I/opt/local/include -fPIC
-F77 = ${MF90}
+F77 = ${MF90} -w -fallow-argument-mismatch
 
 FOMP	= -fopenmp
 FMATH	= -fdefault-real-8 -fdefault-double-8


### PR DESCRIPTION
When installing GACODE using the GFORTRAN_OSX_MACPORTS platform file and instructions I ran into a fatal compilation error:
![PastedGraphic-1](https://user-images.githubusercontent.com/29442575/110552208-30fcf280-8137-11eb-92b0-570cd68b1055.png)

After some digging I found this was likely due to the fact macports had automatically installed gcc-10, which has stricter handling of Fortran argument types.

After reading:
- https://github.com/Reference-ScaLAPACK/scalapack/issues/21
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91731
- https://gcc.gnu.org/onlinedocs/gfortran/Fortran-Dialect-Options.html#Fortran-Dialect-Options

I added "-w -fallow-argument-mismatch" to the gfortran call in the platform file, which according to the documentation linked above turns any errors of mismatching between calls to external procedures and the procedure definitions into warnings, which are suppressed at the same time.

This fixed the issue for me. Since the gcc documentation *strongly* discourages using this option, perhaps in the future fixing the underlying issue of aligning with the stricter argument type requirements in the newer gcc might be necessary.