### PR TITLE
Minor bugfix : Ensure sep initialised to None in prgen_contour

### DIFF
--- a/f2py/pygacode/profiles_gen/prgen_contour.py
+++ b/f2py/pygacode/profiles_gen/prgen_contour.py
@@ -170,6 +170,8 @@ def prgen_contour(geqdsk,nrz,levels,psinorm,narc,quiet):
     kdbgmax=50
     forbidden=[]
     psi1 = None
+    sep = None
+    
     for kdbg in range(kdbgmax):
 
         flx=0.5*(flxM+flxm)


### PR DESCRIPTION
Ensures `sep` is initialised to None prior to possible check in loop of current value.