### PR TITLE
Modified qsub.STELLAR removing explicit memory flag

### DIFF
--- a/platform/qsub/qsub.STELLAR
+++ b/platform/qsub/qsub.STELLAR
@@ -6,7 +6,6 @@ echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
 echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
 echo "#SBATCH -t $WALLTIME" >> $bfile
 echo "#SBATCH -n $cores_used" >> $bfile
-echo "#SBATCH --mem=2GB" >> $bfile
 if [ "$QUEUE" = "null_queue" ]
 then
   echo "#SBATCH" >> $bfile


### PR DESCRIPTION
This pull request removes the line in `qsub.STELLAR` that prohibited regression case `nl01` to execute through `gacode_qsub`.
This line appears to be a holdover from `qsub.PPPL` that was needed for the slurm requirements when submitting batch jobs on portal to dawson, ellis, etc...
Mention @jsachdev