### PR TITLE
Update env.CORI_KNL_HT2_IFORT

### DIFF
--- a/platform/env/env.CORI_KNL_HT2_IFORT
+++ b/platform/env/env.CORI_KNL_HT2_IFORT
@@ -5,7 +5,8 @@ if [ -n "$SSH_TTY" ] ; then
 fi
 
 # Intel 19 compiler is broken
-module swap intel/19.0.3.199 intel/18.0.3.222
+module unload intel  # any intel that is loaded; no error if none is loaded
+module load intel/18.0.3.222
 module load cray-netcdf
 module load cray-fftw
 


### PR DESCRIPTION
Small suggestion to prevent errors when intel/19.0.3.199 is not currently loaded and therefore it cannot be "swapped". Unloading any intel compiler does not throw errors or annoying warnings if no intel compiler is currently loaded. 