### PR TITLE
Fix number of threads being used for serial TGLF runs

### DIFF
--- a/tglf/bin/tglf
+++ b/tglf/bin/tglf
@@ -213,6 +213,7 @@ then
    then
      echo 'no mpi'  >> $RUNBASE
      cd $SIMDIR
+     export OMP_NUM_THREADS=$NOMP
      $TGLF_DIR/src/tglf >> $RUNBASE
    else
      $GACODE_ROOT/platform/exec/exec.$GACODE_PLATFORM \


### PR DESCRIPTION
Without setting the `OMP_NUM_THREADS` environment variable OpenBlas uses all cores available on a system. This is a problem on shared systems as well as when running multiple TGLF instances (eg. during a OMFIT TGLF scan). To read more:
https://github.com/xianyi/OpenBLAS#setting-the-number-of-threads-using-environment-variables

NOTE: We may want to `export OMP_NUM_THREADS=1` also for other serial GACODE executables that use BLAS:
* possible candidates are PROFILES_GEN (which does not seem to use BLAS), LE3, and GLF23
* NEO/GYRO/CGYRO/TGRYRO are always run via `$GACODE_ROOT/platform/exec/exec.$GACODE_PLATFORM`