### PR TITLE
Added NONLINEAR_FIELD input to select which field is used in NL term

### DIFF
--- a/cgyro/bin/cgyro_parse.py
+++ b/cgyro/bin/cgyro_parse.py
@@ -180,6 +180,7 @@ x.add('DLNNDR_5_SCALE','1.0')
 x.add('DLNTDR_5_SCALE','1.0')
 x.add('DLNNDR_6_SCALE','1.0')
 x.add('DLNTDR_6_SCALE','1.0')
+x.add('NONLINEAR_FIELD','0')
 
 # Deprecated parameters
 x.dep('X1','never really existed')

--- a/cgyro/src/cgyro_globals.F90
+++ b/cgyro/src/cgyro_globals.F90
@@ -66,6 +66,7 @@ module cgyro_globals
   integer :: zf_test_mode 
   integer :: nonlinear_flag 
   integer :: nonlinear_method
+  integer :: nonlinear_field
   real :: temp_ae
   real :: dens_ae
   real :: mass_ae

--- a/cgyro/src/cgyro_nl_fftw.f90
+++ b/cgyro/src/cgyro_nl_fftw.f90
@@ -60,16 +60,29 @@ subroutine cgyro_nl_fftw_comm2
 
   call timer_lib_in('nl_mem')
 
+  if (nonlinear_field .ne. 0) then
 !$omp parallel do private(iv_loc,it,iexch,ir)
-  do iv_loc_m=1,nv_loc
-     iexch = (iv_loc_m-1)*n_theta
-     do it=1,n_theta
-        iexch = iexch+1
-        do ir=1,n_radial
-           gpack(ir,iexch) = psi(ic_c(ir,it),iv_loc_m)
+     do iv_loc_m=1,nv_loc
+        iexch = (iv_loc_m-1)*n_theta
+        do it=1,n_theta
+           iexch = iexch+1
+           do ir=1,n_radial
+              gpack(ir,iexch) = jvec_c(nonlinear_field,ic_c(ir,it),iv_loc_m)*field(nonlinear_field,ic_c(ir,it))
+           enddo
         enddo
      enddo
-  enddo
+  else
+!$omp parallel do private(iv_loc,it,iexch,ir)
+     do iv_loc_m=1,nv_loc
+        iexch = (iv_loc_m-1)*n_theta
+        do it=1,n_theta
+           iexch = iexch+1
+           do ir=1,n_radial
+              gpack(ir,iexch) = psi(ic_c(ir,it),iv_loc_m)
+           enddo
+        enddo
+     enddo
+  end if
 
   do iexch=nv_loc*n_theta+1,nsplit*n_toroidal
      gpack(:,iexch) = (0.0,0.0)
@@ -385,7 +398,7 @@ subroutine cgyro_nl_fftw(ij)
      do it=1,n_theta
         iexch = iexch+1
         do ir=1,n_radial
-           psi(ic_c(ir,it),iv_loc) = gpack(ir,iexch) 
+           psi(ic_c(ir,it),iv_loc) = gpack(ir,iexch)
         enddo
      enddo
   enddo

--- a/cgyro/src/cgyro_read_input.f90
+++ b/cgyro/src/cgyro_read_input.f90
@@ -140,6 +140,7 @@ subroutine cgyro_read_input
      call cgyro_readbc_real(x)   ; dlnndr_scale(is) = x
      call cgyro_readbc_real(x)   ; dlntdr_scale(is) = x
   enddo
+  call cgyro_readbc_int(nonlinear_field)
 
   if (i_proc == 0) close(1)
 


### PR DESCRIPTION
I've added in a flag `NONLINEAR_FIELD` that lets you select which field is used in the nonlinear term.

Setting it it:
0: All 3 fields are used (default)
1: Only `phi` is used
2: Only `apar` is used
3: Only `bpar` is used

For example with `NONLINEAR_FIELD=1`, it replaces the nonlinear term as follows:

<img src="https://latex.codecogs.com/gif.latex?%5Cbg_white%20%5Chuge%20%5Bf_%7B0a%7D%20&plus;%20h_a%2C%20%5CPsi%5D%20%5Crightarrow%20%5Bf_%7B0a%7D%20&plus;%20h_a%2C%20G_%7B0a%7D%20%5Cdelta%5Cphi%5D">


This is pretty useful for looking at saturation mechanisms, especially in EM simulations.
