### PR TITLE
Fixed missing direct ICRF heating to electrons from plasmastate file

### DIFF
--- a/profiles_gen/src/allocate_plasmastate_vars.f90
+++ b/profiles_gen/src/allocate_plasmastate_vars.f90
@@ -38,6 +38,7 @@ subroutine allocate_plasmastate_vars
   allocate(plst_pe_trans(nx))
   allocate(plst_pi_trans(nx))
   allocate(plst_peech(nx))
+  allocate(plst_picrf_totals(nx,plst_dp1_nspec_all))
   allocate(plst_pmini(nx))
   allocate(plst_pminth(nx))
   allocate(plst_picth(nx))

--- a/profiles_gen/src/prgen_globals.f90
+++ b/profiles_gen/src/prgen_globals.f90
@@ -217,6 +217,7 @@ module prgen_globals
   real, dimension(:), allocatable :: plst_pbth
   real, dimension(:), allocatable :: plst_qie
   real, dimension(:), allocatable :: plst_peech
+  real, dimension(:,:), allocatable :: plst_picrf_totals     
   real, dimension(:), allocatable :: plst_pohme
   real, dimension(:), allocatable :: plst_pmine
   real, dimension(:), allocatable :: plst_pmini

--- a/profiles_gen/src/prgen_map_plasmastate.f90
+++ b/profiles_gen/src/prgen_map_plasmastate.f90
@@ -254,7 +254,7 @@ subroutine prgen_map_plasmastate
      expro_qohme(i)  = 1e-6*plst_pohme(i-1)/dvol
      expro_qbeame(i) = 1e-6*plst_pbe(i-1)/dvol
      expro_qbeami(i) = 1e-6*(plst_pbi(i-1)+plst_pbth(i-1))/dvol
-     expro_qrfe(i)   = 1e-6*(plst_peech(i-1)+plst_pmine(i-1))/dvol
+     expro_qrfe(i)   = 1e-6*(plst_peech(i-1)+plst_pmine(i-1)+plst_picrf_totals(i-1,1))/dvol ! ECH + ICRF minority + ICRF direct
      expro_qrfi(i)   = 1e-6*(plst_pmini(i-1)+plst_pminth(i-1)+plst_picth(i-1))/dvol
 
      ! Radiation

--- a/profiles_gen/src/prgen_read_plasmastate.f90
+++ b/profiles_gen/src/prgen_read_plasmastate.f90
@@ -406,6 +406,15 @@ subroutine prgen_read_plasmastate
      plst_peech(:) = 0.0
   endif
 
+  ! Total ICRF power (to grab the ICRF direct power to electrons)
+  err = nf90_inq_varid(ncid,trim('picrf_totals'),varid)
+  if (err == 0) then
+     err = nf90_get_var(ncid,varid,plst_picrf_totals(1:nx-1,1))
+  else
+     plst_picrf_totals(:,:) = 0.0
+  endif
+
+
   ! Ohmic heating power to electrons
   err = nf90_inq_varid(ncid,trim('pohme'),varid)
   if (err == 0) then


### PR DESCRIPTION
This pull request solves #211.
Summary of the issue:
- ICRF waves can heat directly the electrons through Landau damping, but that power was not read from the plasmastate file to include in input.gacode.
- Consequently, this power was included in the `qione` variable.

Summary of proposed solution with this PR:
- plasmastate variable `picrf_totals` (defined as "direct ICRF power deposition", see #211 for more info) contains all powers. First is electrons, so this pull requests allocates this variable and then adds the electron power to the `qrfe` variable.

I coded this to the best of my understanding on how profiles_gen works, but I'm not a fortran code writer, so please review if this is the way to do it.
