### PR TITLE
Add explicit node count to batch.src

### DIFF
--- a/platform/qsub/qsub.PERLMUTTER_GPU
+++ b/platform/qsub/qsub.PERLMUTTER_GPU
@@ -17,6 +17,7 @@ echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
 echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
 echo "#SBATCH -q $QUEUE" >> $bfile
 echo "#SBATCH -t $WALLTIME" >> $bfile
+echo "#SBATCH -N $nodes" >> $bfile
 echo "#SBATCH -n $nmpi" >> $bfile
 echo "#SBATCH -c $nomp" >> $bfile
 echo "#SBATCH --gpus-per-node=4" >> $bfile


### PR DESCRIPTION
When a job needs less cores than there are available ones, we want to explicitly provide the number of nodes to SLURM.
(we already had the info in gacode_qsub, we just were not passing it on)