### PR TITLE
pygacode:Include numpy dependency systematically

### DIFF
--- a/f2py/setup.py
+++ b/f2py/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
         'numpy'
     ],)
 from numpy.distutils.core import setup, Extension
+from distutils.command.sdist import sdist
 
 wrapper = Extension('gacode_ext',
                     sources=['expro/expro.f90',
@@ -63,7 +64,8 @@ setup(name='pygacode',
       package_data={'pygacode.test': ['input.gacode'],
                     'pygacode': ['version']},
       packages=['pygacode', 'pygacode.test', 'pygacode.gyro', 'pygacode.cgyro', 'pygacode.tgyro', 'pygacode.neo', 'pygacode.profiles_gen'],
-      ext_modules=[wrapper]
+      ext_modules=[wrapper],
+      cmdclass={'sdist': sdist}
       )
 
 # only run tests when installing


### PR DESCRIPTION
@jcandy @orso82 
I don't remember which of you releases new versions of pygacode, but please try it out with the changes here to require `numpy` during the build process.  This should help as per https://stackoverflow.com/questions/60045913/installing-numpy-before-using-numpy-distutils-core-setup .  Also, this will hopefully resolve https://github.com/gafusion/omas/issues/213