### PR TITLE
Use a 1.e-2 energy cutoff for coll_fp32

### DIFF
--- a/cgyro/src/cgyro_check_memory.F90
+++ b/cgyro/src/cgyro_check_memory.F90
@@ -149,8 +149,8 @@ subroutine cgyro_check_memory(datafile)
            call cgyro_alloc_add(io,(8.0*nv)*nv*nc_loc,'cmat')
         else
            call cgyro_alloc_add(io,4.0*nv*nv*nc_loc,'cmat_fp32')
-           call cgyro_alloc_add(io,4.0*n_xi*n_species*(n_energy-1)*n_xi*nc_loc,'cmat_stripes')
-           call cgyro_alloc_add(io,4.0*n_xi*n_species*nv*nc_loc,'cmat_e1')
+           call cgyro_alloc_add(io,4.0*n_xi*n_species*(n_energy-n_low_energy)*n_xi*nc_loc,'cmat_stripes')
+           call cgyro_alloc_add(io,4.0*n_xi*n_species*nv*nc_loc*n_low_energy,'cmat_e1')
         endif
 #ifdef _OPENACC
         if (gpu_bigmem_flag /= 1) then

--- a/cgyro/src/cgyro_globals.F90
+++ b/cgyro/src/cgyro_globals.F90
@@ -443,10 +443,11 @@ module cgyro_globals
   real, dimension(:,:,:), allocatable :: hzf,xzf 
   !
   ! Collision operator
+  integer :: n_low_energy
   real, dimension(:,:,:), allocatable :: cmat ! only used if collision_precision_mode=0
   real(KIND=REAL32), dimension(:,:,:), allocatable :: cmat_fp32 ! only used if collision_precision_mod/=0
   real(KIND=REAL32), dimension(:,:,:,:,:), allocatable :: cmat_stripes ! only used if collision_precision_mod/=0
-  real(KIND=REAL32), dimension(:,:,:,:), allocatable :: cmat_e1 ! only used if collision_precision_mod/=0
+  real(KIND=REAL32), dimension(:,:,:,:,:), allocatable :: cmat_e1 ! only used if collision_precision_mod/=0
   real, dimension(:,:,:,:,:), allocatable :: cmat_simple ! only used in collision_model=5
   ! 
   ! Equilibrium/geometry arrays

--- a/cgyro/src/cgyro_init_collision.f90
+++ b/cgyro/src/cgyro_init_collision.f90
@@ -246,7 +246,7 @@ subroutine cgyro_init_collision
 !$omp& private(iv,is,ix,ie,jv,js,jx,je,ks) &
 !$omp& private(amat_sum,cmat_sum,cmat_diff,cmat_rel_diff) shared (cmap_fp32_error_abs_cnt_loc,cmap_fp32_error_rel_cnt_loc) &
 !$omp& private(amat,cmat_loc,i_piv,rs,rsvec,rsvect0,rsvect1) &
-!$omp& firstprivate(collision_precision_mode) &
+!$omp& firstprivate(collision_precision_mode,n_low_energy) &
 !$omp& shared(cmat,cmat_fp32,cmat_stripes,cmat_e1)
   do ic=nc1,nc2
    
@@ -671,9 +671,9 @@ subroutine cgyro_init_collision
               ie = ie_v(iv)
               is = is_v(iv)
               ix = ix_v(iv)
-              if (ie==1) then ! always keep all detail for top energy
-                 cmat_e1(ix,is,jv,ic_loc) = amat(iv,jv) - cmat_fp32(iv,jv,ic_loc)
-                 cmat_sum = cmat_sum + abs(cmat_fp32(iv,jv,ic_loc) + cmat_e1(ix,is,jv,ic_loc))
+              if (ie<=n_low_energy) then ! always keep all detail for lowest energy
+                 cmat_e1(ix,is,ie,jv,ic_loc) = amat(iv,jv) - cmat_fp32(iv,jv,ic_loc)
+                 cmat_sum = cmat_sum + abs(cmat_fp32(iv,jv,ic_loc) + cmat_e1(ix,is,ie,jv,ic_loc))
               else ! only keep if energy and species the same
                  if ((je == ie) .AND. (js == is)) then
                     cmat_stripes(ix,is,ie,jx,ic_loc) = amat(iv,jv) - cmat_fp32(iv,jv,ic_loc)

--- a/cgyro/src/cgyro_step_collision.F90
+++ b/cgyro/src/cgyro_step_collision.F90
@@ -107,8 +107,8 @@ subroutine cgyro_calc_collision_cpu_fp32(nj_loc,update_chv)
            ie = ie_v(iv)
            is = is_v(iv)
            ix = ix_v(iv)
-           if (ie==1) then
-             cval = cval + cmat_e1(ix,is,ivp,ic_loc)
+           if (ie<=n_low_energy) then
+             cval = cval + cmat_e1(ix,is,ie,ivp,ic_loc)
            else
              if ((iep==ie) .AND. (isp==is)) then
                cval = cval + cmat_stripes(ix,is,ie,ixp,ic_loc)
@@ -478,8 +478,8 @@ subroutine cgyro_calc_collision_gpu_fp32(nj_loc,update_chv)
               cval = cmat_fp32(iv,ivp,ic_loc)
               h_re = real(cap_h_v(ic_loc,ivp))
               h_im = aimag(cap_h_v(ic_loc,ivp))
-              if (ie==1) then
-                 cval = cval + cmat_e1(ix,is,ivp,ic_loc)
+              if (ie<=n_low_energy) then
+                 cval = cval + cmat_e1(ix,is,ie,ivp,ic_loc)
               else
                  iep = ie_v(ivp)
                  isp = is_v(ivp)
@@ -568,8 +568,8 @@ subroutine cgyro_calc_collision_gpu_b2_fp32(nj_loc,update_chv)
               cval = cmat_fp32(iv,ivp,ic_loc)
               h_re = real(cap_h_v(ic_loc,ivp))
               h_im = aimag(cap_h_v(ic_loc,ivp))
-              if (ie==1) then
-                 cval = cval + cmat_e1(ix,is,ivp,ic_loc)
+              if (ie<=n_low_energy) then
+                 cval = cval + cmat_e1(ix,is,ie,ivp,ic_loc)
               else
                  iep = ie_v(ivp)
                  isp = is_v(ivp)


### PR DESCRIPTION
Instead of using a fixed single energy cmat_e1, determine the appropriate number using the energy value.
Use a cutoff of 1.e-2.