### PR TITLE
Add PERLMUTTER_GPU_80G platform

### DIFF
--- a/cgyro/install/make.ext.PERLMUTTER_GPU_80G
+++ b/cgyro/install/make.ext.PERLMUTTER_GPU_80G
@@ -1,0 +1,4 @@
+cgyro_nl_fftw.o : cgyro_nl_fftw.gpu.f90
+	$(FC) $(FMATH) $(FFLAGS) -o cgyro_nl_fftw.o -c cgyro_nl_fftw.gpu.f90
+cgyro_rhs.o : cgyro_rhs.gpu.f90
+	$(FC) $(FMATH) $(FFLAGS) -o cgyro_rhs.o -c cgyro_rhs.gpu.f90

--- a/platform/build/make.inc.PERLMUTTER_GPU_80G
+++ b/platform/build/make.inc.PERLMUTTER_GPU_80G
@@ -1,0 +1,35 @@
+#----------------------------------------------------------
+# Cray EX (perlmutter.nersc.gov) [GPU nodes]
+#
+# - 128 CPU cores (AMD Epyc) + 4 GPUs (A100)
+#----------------------------------------------------------
+
+IDENTITY="NERSC Perlmutter GPU"
+CORES_PER_NODE=128
+NUMAS_PER_NODE=4
+
+# Fortran 90/95 compiler
+FC = ftn -module ${GACODE_ROOT}/modules -Mpreprocess -DUSE_INLINE -craype-verbose -Mdefaultunit
+
+# Fortran 77 compiler
+F77 = ${FC}
+
+# Compiler options/flags
+FACC   =-acc -Minfo=accel -target-accel=nvidia80 -Mcudalib=cufft
+FOMP   =-mp -Mstack_arrays 
+FMATH  =-r8 
+FOPT   =-fast
+FDEBUG =-g -Kieee -Ktrap=fp,divz -Mbounds -Mchkptr -Mchkstk -traceback -Minform=inform
+F2PY   = f2py --fcompiler=pg
+
+
+# System math libraries
+LMATH=-llapack -lblas
+
+# NetCDF
+NETCDF=-L${NETCDF_DIR}/lib -lnetcdff -lnetcdf
+NETCDF_INC = ${NETCDF_DIR}/include
+
+# Archive 
+ARCH = ar cr
+

--- a/platform/env/env.PERLMUTTER_GPU_80G
+++ b/platform/env/env.PERLMUTTER_GPU_80G
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -n "$SSH_TTY" ] ; then
+   echo "Setting up $GACODE_PLATFORM environment for gacode"
+fi
+
+export CRAY_ACCEL_TARGET=nvidia80
+
+module purge
+module load craype-x86-milan
+module load PrgEnv-nvidia
+module load cray-hdf5
+module load cray-netcdf
+module load python
+module load cudatoolkit

--- a/platform/exec/exec.PERLMUTTER_GPU_80G
+++ b/platform/exec/exec.PERLMUTTER_GPU_80G
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash 
+# GACODE Parallel execution script
+
+simdir=${1}
+nmpi=${2}
+exec=${3}
+nomp=${4}
+numa=${5}
+mpinuma=${6}
+
+# nmpi = MPI tasks
+# nomp = OpenMP threads per MPI task
+# numa = NUMAs active per node
+# mpinuma = MPI tasks per active NUMA 
+
+. $GACODE_ROOT/shared/bin/gacode_mpi_tool
+
+cd $simdir
+
+let proc_per_node=$CORES_PER_NODE/$nomp
+
+export MPICH_MAX_THREAD_SAFETY=funneled
+export OMP_NUM_THREADS=$nomp
+export OMP_STACKSIZE=400M
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+export SLURM_CPU_BIND="cores"
+ulimit -c unlimited
+
+echo "> srun -C gpu --cpu_bind=cores -n $nmpi -c $nomp $GACODE_ROOT/platform/exec/wrap.${GACODE_PLATFORM} $exec"
+srun -C gpu --cpu_bind=cores -n $nmpi -c $nomp $GACODE_ROOT/platform/exec/wrap.${GACODE_PLATFORM} $exec

--- a/platform/exec/wrap.PERLMUTTER_GPU_80G
+++ b/platform/exec/wrap.PERLMUTTER_GPU_80G
@@ -1,0 +1,50 @@
+#! /usr/bin/env bash
+# GACODE Parallel execution script (PERLMUTTER_GPU)
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+#env 1>&2
+
+#echo $SLURM_LOCALID
+let r4=SLURM_LOCALID/4
+let l4="$SLURM_LOCALID-($r4*4)"
+# GPU3 is connected to CPU0
+let ACC_DEVICE_NUM=3-${l4}
+export ACC_DEVICE_NUM
+
+echo "`uname -n` $SLURM_PROCID $SLURM_LOCALID $ACC_DEVICE_NUM `taskset -pc $$`"
+#ecno "uname -n` $SLURM_LOCALID LL $LD_LIBRARY_PATH"
+
+NTASKS_PER_NODE=$((SLURM_NTASKS / SLURM_NNODES))
+
+if [ ${NTASKS_PER_NODE} -gt 4 ]; then
+  # use MPS
+  # https://docs.nvidia.com/deploy/mps/index.html
+  export CUDA_MPS_PIPE_DIRECTORY=/tmp/nvidia-mps
+  export CUDA_MPS_LOG_DIRECTORY=/tmp/nvidia-log
+
+  NODE_RANK=$((SLURM_PROCID % NTASKS_PER_NODE))
+
+  if [ $NODE_RANK -eq 0 ]; then
+    echo $SLURM_PROCID starting nvidia-cuda-mps-control on $(hostname)
+    nvidia-cuda-mps-control -d
+  fi
+
+  sleep 5
+
+  if [ $NODE_RANK -eq 0 ]; then
+    echo "`uname -n` $SLURM_PROCID $SLURM_LOCALID mps ready: $(date --iso-8601=seconds)"
+  fi
+
+  "$@"
+
+  if [ $NODE_RANK -eq 0 ]; then
+    echo "`uname -n` $SLURM_PROCID $SLURM_LOCALID stopping nvidia-cuda-mps-control: $(date --iso-8601=seconds)"
+    echo quit | nvidia-cuda-mps-control
+    echo "`uname -n` $SLURM_PROCID $SLURM_LOCALID stopped nvidia-cuda-mps-control: $(date --iso-8601=seconds)"
+  fi
+else
+  # no need for MPS
+  exec  "$@"
+fi
+

--- a/platform/qsub/qsub.PERLMUTTER_GPU_80G
+++ b/platform/qsub/qsub.PERLMUTTER_GPU_80G
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "-queue: default [default], debug, premium"
+
+# Default queue
+if [ "$QUEUE" == "null_queue" ] ; then
+   QUEUE=default
+fi
+
+bfile=$SIMDIR/batch.src
+
+echo "#!/bin/bash -l" > $bfile
+echo "#SBATCH -J $LOCDIR" >> $bfile
+echo "#SBATCH -A $REPO" >> $bfile
+echo "#SBATCH -C gpu&hbm80g" >> $bfile
+echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
+echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
+echo "#SBATCH -q $QUEUE" >> $bfile
+echo "#SBATCH -t $WALLTIME" >> $bfile
+echo "#SBATCH -N $nodes" >> $bfile
+echo "#SBATCH -n $nmpi" >> $bfile
+echo "#SBATCH -c $nomp" >> $bfile
+echo "#SBATCH --gpus-per-node=4" >> $bfile
+echo 'export SLURM_CPU_BIND="cores"' >> $bfile
+echo "$CODE -e $LOCDIR -n $nmpi -nomp $nomp -numa $numa -mpinuma $mpinuma -p $SIMROOT" >> $bfile 


### PR DESCRIPTION
Perlmutter now has 80GB A100s.
These are great for when you have a large problems and want to keep the number of nodes as low as possible.
This adds a new GACODE_PLATFORM for this.