### PR TITLE
Optimize cgyro_advect_wavenumber

### DIFF
--- a/cgyro/src/cgyro_advect_wavenumber.F90
+++ b/cgyro/src/cgyro_advect_wavenumber.F90
@@ -13,51 +13,51 @@ subroutine cgyro_advect_wavenumber(ij)
   implicit none
 
   integer, intent(in) :: ij
-  integer :: ir,l,ll,j,icc,ivc,itor
-  complex, dimension(:,:),allocatable :: he
-  complex :: rl
+  integer :: ir,l,ll,j,iccj,ivc,itor,llnt
+  complex :: rl,he1,he2
 
   if (nonlinear_flag == 0) return
 
   if (source_flag == 1) then
      call timer_lib_in('shear')
-     allocate(he(n_theta,1-2*n_wave:n_radial+2*n_wave))
 
 #ifdef _OPENACC
-!$acc parallel loop collapse(2) gang private(ivc,ir,l,icc,ll,he) &
+!$acc parallel loop collapse(2) gang private(ivc,ir,l,iccj) &
 !$acc&                   present(rhs(:,:,:,ij),omega_ss,field,h_x,c_wave)
 #else
-!$omp parallel do collapse(2) private(ivc,ir,j,icc,l,ll,rl,he)
+!$omp parallel do collapse(2) private(ivc,ir,j,iccj,l,ll,rl,llnt,he1,he2)
 #endif
      do itor=nt1,nt2
       do ivc=1,nv_loc
-        he(:,1-2*n_wave:0) = 0.0
-        he(:,n_radial+1:n_radial+2*n_wave) = 0.0
 
         ! Wavenumber advection ExB shear
         if (shear_method == 2) then
-
-!$acc loop collapse(2) vector private(ir,icc,j)
+!$acc loop collapse(2) vector private(ir,j,l,iccj,ll,rl,llnt,he1,he2)
            do ir=1,n_radial
               do j=1,n_theta
-                 icc = (ir-1)*n_theta
-                 he(j,ir) = omega_eb_base*itor*h_x(icc+j,ivc,itor)
-              enddo
-           enddo
-
-!$acc loop collapse(2) vector private(ir,j,l,icc,ll,rl)
-           do ir=1,n_radial
-              do j=1,n_theta
-                 icc = (ir-1)*n_theta
-                 rl = rhs(icc+j,ivc,itor,ij)
+                 iccj = (ir-1)*n_theta+j
+                 rl = 0.0
 !$acc loop seq
                  do l=1,n_wave
-                    ll = 2*l-1
+                    ll = (2*l-1)
+                    llnt = ll*n_theta
+                    ! was he(j,ir+ll)
+                    if ( (ir+ll) <= n_radial ) then
+                       he1 = h_x(iccj+llnt,ivc,itor)
+                    else
+                       he1 = 0.0
+                    endif
+                    ! was he(j,ir-ll)
+                    if ( (ir-ll) >= 1 ) then
+                       he2 = h_x(iccj-llnt,ivc,itor)
+                    else
+                       he2 = 0.0
+                    endif
                     ! Sign throughout paper is incorrect (or gamma -> - gamma)
                     ! Thus sign below has been checked and is correct
-                    rl = rl+c_wave(l)*(he(j,ir+ll)-he(j,ir-ll))
+                    rl = rl+c_wave(l)*(he1-he2)
                  enddo
-                 rhs(icc+j,ivc,itor,ij) = rl
+                 rhs(iccj,ivc,itor,ij) = rhs(iccj,ivc,itor,ij) + omega_eb_base*itor*rl
               enddo
            enddo
 
@@ -66,26 +66,31 @@ subroutine cgyro_advect_wavenumber(ij)
         ! Wavenumber advection profile shear
         if (profile_shear_flag == 1) then
 
-!$acc loop collapse(2) vector private(ir,icc,j)
+!$acc loop collapse(2) vector private(ir,j,l,iccj,ll,rl,llnt,he1,he2)
            do ir=1,n_radial
               do j=1,n_theta
-                 icc = (ir-1)*n_theta
-                 he(j,ir) = sum(omega_ss(:,icc+j,ivc,itor)*field(:,icc+j,itor))
-              enddo
-           enddo
-
-!$acc loop collapse(2) vector private(ir,j,l,icc,ll,rl)
-           do ir=1,n_radial
-              do j=1,n_theta
-                 icc = (ir-1)*n_theta
-                 rl = rhs(icc+j,ivc,itor,ij)
+                 iccj = (ir-1)*n_theta+j
+                 rl = rhs(iccj,ivc,itor,ij)
 !$acc loop seq
                  do l=1,n_wave
                     ll = 2*l-1
+                    llnt = ll*n_theta
+                    ! was he(j,ir+ll)
+                    if ( (ir+ll) <= n_radial ) then
+                       he1 = sum(omega_ss(:,iccj+llnt,ivc,itor)*field(:,iccj+llnt,itor))
+                    else
+                       he1 = 0.0
+                    endif
+                    ! was he(j,ir-ll)
+                    if ( (ir-ll) >= 1 ) then
+                       he2 = sum(omega_ss(:,iccj-llnt,ivc,itor)*field(:,iccj-llnt,itor))
+                    else
+                       he2 = 0.0
+                    endif
                     ! Note opposite sign to ExB shear
-                    rl = rl-c_wave(l)*(he(j,ir+ll)-he(j,ir-ll))
+                    rl = rl-c_wave(l)*(he1-he2)
                  enddo
-                 rhs(icc+j,ivc,itor,ij) = rl
+                 rhs(iccj,ivc,itor,ij) = rl
               enddo
            enddo
 
@@ -93,7 +98,6 @@ subroutine cgyro_advect_wavenumber(ij)
       enddo
      enddo
 
-     deallocate(he)
      call timer_lib_out('shear')
 
   endif


### PR DESCRIPTION
Remove the intermediate table pre-compute and just compute where needed.
Drastically speeds up the compute on GPUs (up to 40x on CRUSHER, more than 2x on Perlmutter for sh03)
Minor advantage on CPUs.