### PR TITLE
Optimize upwind by removing reductions

### DIFF
--- a/cgyro/src/cgyro_upwind.F90
+++ b/cgyro/src/cgyro_upwind.F90
@@ -24,9 +24,7 @@ subroutine cgyro_upwind_r64
   implicit none
 
   integer :: is,ie,ix,itor
-#ifdef _OPENACC
   complex :: res_loc
-#endif
 
   call timer_lib_in('str')
 
@@ -34,7 +32,11 @@ subroutine cgyro_upwind_r64
 !$acc parallel loop collapse(3) gang vector independent &
 !$acc&         private(res_loc,iv,iv_loc) &
 !$acc&         present(g_x,upfac1,is_v,upwind_res_loc) &
-!$acc&        present(nt1,nt2,ns1,ns2,nc,nv1,nv2) default(none)
+!$acc&         present(nt1,nt2,ns1,ns2,nc,nv1,nv2) default(none)
+#else
+!$omp parallel do collapse(3) &
+!$omp&         private(res_loc,iv,iv_loc) &
+#endif
   do itor=nt1,nt2
    do is=ns1,ns2
      do ic=1,nc
@@ -49,23 +51,6 @@ subroutine cgyro_upwind_r64
     enddo
    enddo
   enddo
-#else
-  upwind_res_loc(:,:,:) = (0.0,0.0)
-
-!$omp parallel private(iv_loc,ic,is)
-!$omp do collapse(2) reduction(+:upwind_res_loc)
-  do itor=nt1,nt2
-   do iv=nv1,nv2
-     iv_loc = iv-nv1+1
-     is = is_v(iv)
-     do ic=1,nc
-        upwind_res_loc(ic,is,itor) = upwind_res_loc(ic,is,itor)+upfac1(ic,iv_loc,itor)*g_x(ic,iv_loc,itor)
-     enddo
-   enddo
-  enddo
-!$omp end do
-!$omp end parallel
-#endif
 
   call timer_lib_out('str')
 
@@ -129,9 +114,7 @@ subroutine cgyro_upwind_r32
   implicit none
 
   integer :: is,ie,ix,itor
-#ifdef _OPENACC
   complex(KIND=REAL32) :: res_loc
-#endif
 
   call timer_lib_in('str')
 
@@ -140,6 +123,10 @@ subroutine cgyro_upwind_r32
 !$acc&         private(res_loc,iv,iv_loc) &
 !$acc&         present(g_x,upfac1,is_v,upwind32_res_loc) &
 !$acc&         present(nt1,nt2,ns1,ns2,nc,nv1,nv2) default(none)
+#else
+!$omp parallel do collapse(3) &
+!$omp&         private(res_loc,iv,iv_loc) &
+#endif
   do itor=nt1,nt2
    do is=ns1,ns2
      do ic=1,nc
@@ -155,23 +142,6 @@ subroutine cgyro_upwind_r32
     enddo
    enddo
   enddo
-#else
-  upwind32_res_loc(:,:,:) = (0.0,0.0)
-
-!$omp parallel private(iv_loc,ic,is)
-!$omp do collapse(2) reduction(+:upwind32_res_loc)
-  do itor=nt1,nt2
-   do iv=nv1,nv2
-     iv_loc = iv-nv1+1
-     is = is_v(iv)
-     do ic=1,nc
-        upwind32_res_loc(ic,is,itor) = upwind32_res_loc(ic,is,itor)+upfac1(ic,iv_loc,itor)*g_x(ic,iv_loc,itor)
-     enddo
-   enddo
-  enddo
-!$omp end do
-!$omp end parallel
-#endif
 
   call timer_lib_out('str')
 


### PR DESCRIPTION
Reordered the loops so there is no need for reductions.
About 2x speedup on CPU and NVIDIA GPU. Over 10x speedup on CRUSHER.