### PR TITLE
Fix kygridmodel=4 bug

### DIFF
--- a/tglf/src/tglf_kygrid.f90
+++ b/tglf/src/tglf_kygrid.f90
@@ -170,14 +170,16 @@
         ky_spectrum(4) = 4.0*ky_min
         dky_spectrum(4) = ky_min
         ky_spectrum(5) = 5.0*ky_min
-        dky_spectrum(5) = ky_min        
-        ky_min = ky_spectrum(5)
+        dky_spectrum(5) = ky_min  
+        ky_spectrum(6) = 6.0*ky_min
+        dky_spectrum(6) = ky_min       
+        ky_min = ky_spectrum(6)
 !        ky_max = 1.0*ky_factor*ABS(zs(2))/SQRT(taus(2)*mass(2))
         ky_max = 1.0*ky_factor/rho_ion
 !        dky0 = 0.1*ky_factor*ABS(zs(2))/SQRT(taus(2)*mass(2))
         dky0 = 0.1*ky_factor/rho_ion
-        do i=6,nky
-          ky_spectrum(i) = ky_min + REAL(i-4)*dky0
+        do i=7,nky
+          ky_spectrum(i) = ky_min + REAL(i-6)*dky0
           dky_spectrum(i) = dky0
         enddo
 !        ky0 = 1.0*ky_factor*ABS(zs(2))/SQRT(taus(2)*mass(2))


### PR DESCRIPTION
When running with KYGRID_MODEL = 4, the following is produced for out.tglf.ky_spectrum:

<img width="239" alt="Screenshot 2023-12-01 at 14 11 44" src="https://github.com/gafusion/gacode/assets/47749334/0ba89c83-425f-4f63-b9b4-ae54dbcb7e14">

Note the jump from 0.25 to 0.45, as well as the sequence (0.95, 1.05, 1.00). This PR proposes to fix this bug, such that out.tglf.ky_spectrum for KYGRID_MODEL = 4 produces 

<img width="241" alt="Screenshot 2023-12-01 at 14 05 50" src="https://github.com/gafusion/gacode/assets/47749334/7360c149-1841-4818-accb-3e8147d8bd4b">

which samples the ion scale in intervals of 0.1, with 0.05, 0.15 and 0.25 included.