### PR TITLE
Properly handle nsplit=1

### DIFF
--- a/cgyro/src/cgyro_nl_comm.F90
+++ b/cgyro/src/cgyro_nl_comm.F90
@@ -48,6 +48,8 @@ subroutine cgyro_nl_fftw_comm1_async
 
   call timer_lib_in('nl_mem')
 
+  if (nsplitB > 0) then
+
 #if defined(OMPGPU)
 !$omp target teams distribute parallel do simd collapse(4) &
 !$omp&         private(iexch0,itor0,isplit0,iexch_base,h_loc)
@@ -102,12 +104,62 @@ subroutine cgyro_nl_fftw_comm1_async
     enddo
   endif
 
+  else ! nsplitB==0
+
+#if defined(OMPGPU)
+!$omp target teams distribute parallel do simd collapse(4) &
+!$omp&         private(iexch0,itor0,isplit0,iexch_base,h_loc)
+#elif defined(_OPENACC)
+!$acc parallel loop collapse(4) gang vector independent &
+!$acc&         private(iexch0,itor0,isplit0,iexch_base,h_loc) &
+!$acc&         present(ic_c,h_x,fpackA) &
+!$acc&         present(n_theta,nv_loc,nt1,nt2,n_radial,nsplit,nsplitA) default(none)
+#else
+!$omp parallel do collapse(3) &
+!$omp&         private(iexch0,itor0,isplit0,iexch_base,h_loc)
+#endif
+  do it=1,n_theta
+   do iv_loc_m=1,nv_loc
+    do itor=nt1,nt2
+     do ir=1,n_radial
+       h_loc = h_x(ic_c(ir,it),iv_loc_m,itor)
+       iexch0 = (iv_loc_m-1) + (it-1)*nv_loc
+       itor0 = iexch0/nsplit
+       isplit0 = modulo(iexch0,nsplit)
+       iexch_base = 1+itor0*nsplitA
+       fpackA(ir,itor-nt1+1,iexch_base+isplit0) = h_loc
+     enddo
+    enddo
+   enddo
+  enddo
+
+  if ( (nv_loc*n_theta) < (nsplit*n_toroidal_procs) ) then
+#if defined(OMPGPU)
+!$omp target teams distribute parallel do simd &
+!$omp&         private(iexch0,itor0,isplit0,iexch_base)
+#elif defined(_OPENACC)
+!$acc parallel loop independent gang vector &
+!$acc&         private(iexch0,itor0,isplit0,iexch_base) &
+!$acc&         present(fpackA,nsplit,nsplitA)
+#endif
+    do iexch0=nv_loc*n_theta,nsplit*n_toroidal_procs-1
+       itor0 = iexch0/nsplit
+       isplit0 = modulo(iexch0,nsplit)
+       iexch_base = 1+itor0*nsplitA
+       fpackA(1:n_radial,1:nt_loc,iexch_base+isplit0) = (0.0,0.0)
+    enddo
+  endif
+
+  endif ! if nspliB>0
+
+  call timer_lib_out('nl_mem')
+
+  call timer_lib_in('nl_comm')
   ! split the comm in two, so we can start working on first as soon as it is ready
   call parallel_slib_f_nc_async(nsplitA,fpackA,fA_nl,fA_req)
   fA_req_valid = .TRUE.
   ! send only the first half, use comm3 to send the other half
-
-  call timer_lib_out('nl_mem')
+  call timer_lib_out('nl_comm')
 
 end subroutine cgyro_nl_fftw_comm1_async
 
@@ -118,8 +170,14 @@ subroutine cgyro_nl_fftw_comm3_async
 
   implicit none
 
-  call parallel_slib_f_nc_async(nsplitB,fpackB,fB_nl,fB_req)
-  fB_req_valid = .TRUE.
+  if (nsplitB > 0) then
+    call timer_lib_in('nl_comm')
+
+    call parallel_slib_f_nc_async(nsplitB,fpackB,fB_nl,fB_req)
+    fB_req_valid = .TRUE.
+
+    call timer_lib_out('nl_comm')
+  endif
 end subroutine cgyro_nl_fftw_comm3_async
 
 subroutine cgyro_nl_fftw_comm1_r(ij)
@@ -141,14 +199,18 @@ subroutine cgyro_nl_fftw_comm1_r(ij)
   call timer_lib_in('nl_comm')
   call parallel_slib_r_nc_wait(nsplitA,fA_nl,fpackA,fA_req)
   fA_req_valid = .FALSE.
-  ! no major compute to overlap
-  call parallel_slib_r_nc_wait(nsplitB,fB_nl,fpackB,fB_req)
-  fB_req_valid = .FALSE.
+  if (nsplitB > 0) then
+    ! no major compute to overlap
+    call parallel_slib_r_nc_wait(nsplitB,fB_nl,fpackB,fB_req)
+    fB_req_valid = .FALSE.
+  endif
   call timer_lib_out('nl_comm')
 
   call timer_lib_in('nl')
 
   psi_mul = (q*rho/rmin)*(2*pi/length)
+
+  if (nsplitB > 0) then
 
 #if defined(OMPGPU)
 !$omp target teams distribute parallel do simd collapse(4) &
@@ -193,6 +255,49 @@ subroutine cgyro_nl_fftw_comm1_r(ij)
       enddo
     enddo
   enddo
+
+  else ! nsplitB==0
+
+#if defined(OMPGPU)
+!$omp target teams distribute parallel do simd collapse(4) &
+!$omp&         private(iexch0,itor0,isplit0,iexch_base) &
+!$omp&         private(ic_loc_m,my_psi)
+#elif defined(_OPENACC)
+!$acc parallel loop collapse(4) gang vector independent private(ic_loc_m,my_psi) &
+!$acc&         private(iexch0,itor0,isplit0,iexch_base) &
+!$acc&         present(ic_c,px,rhs,fpackA) copyin(psi_mul,zf_scale) &
+!$acc&         present(nt1,nt2,nv_loc,n_theta,n_radial,nsplit,nsplitA) copyin(ij) default(none)
+#else
+!$omp parallel do collapse(2) private(ic_loc_m,my_psi) &
+!$omp&         private(iexch0,itor0,isplit0,iexch_base)
+#endif
+  do itor=nt1,nt2
+    do iv_loc_m=1,nv_loc
+      do it=1,n_theta
+        do ir=1,n_radial
+           ic_loc_m = ic_c(ir,it)
+           if ( (itor == 0) .and.  (ir == 1 .or. px(ir) == 0) ) then
+              ! filter
+              my_psi = (0.0,0.0)
+           else
+              iexch0 = (iv_loc_m-1) + (it-1)*nv_loc
+              itor0 = iexch0/nsplit
+              isplit0 = modulo(iexch0,nsplit)
+              iexch_base = 1+itor0*nsplitA
+              my_psi = fpackA(ir,itor-nt1+1,iexch_base+isplit0)
+           endif           
+           if (itor == 0) then
+              my_psi = my_psi*zf_scale
+           endif
+           
+           ! RHS -> -[f,g] = [f,g]_{r,-alpha}
+           rhs(ic_loc_m,iv_loc_m,itor,ij) = rhs(ic_loc_m,iv_loc_m,itor,ij)+psi_mul*my_psi
+        enddo
+      enddo
+    enddo
+  enddo
+
+  endif ! if nsplitB>0
 
   call timer_lib_out('nl')
 
@@ -258,10 +363,13 @@ subroutine cgyro_nl_fftw_comm2_async
    enddo
   enddo
 
+  call timer_lib_out('nl_mem')
+
+  call timer_lib_in('nl_comm')
   call parallel_slib_f_fd_async(n_field,n_radial,n_jtheta,gpack,g_nl,g_req)
   g_req_valid = .TRUE.
 
-  call timer_lib_out('nl_mem')
+  call timer_lib_out('nl_comm')
 
 end subroutine cgyro_nl_fftw_comm2_async
 


### PR DESCRIPTION
#333 split nsplit communication in two, potentially resulting in one half to be empty.
This PR properly deals with that use-case.