### PR TITLE
Improve MPI split reporting, fix velocity_order=2 handling

### DIFF
--- a/cgyro/src/cgyro.f90
+++ b/cgyro/src/cgyro.f90
@@ -62,8 +62,10 @@ program cgyro
   call timer_lib_out('input')
 
   call cgyro_init_kernel
-  call cgyro_kernel
-  call cgyro_final_kernel
+  if (error_status == 0) then
+        call cgyro_kernel
+        call cgyro_final_kernel
+  endif
   call MPI_FINALIZE(i_err)
 
 end program cgyro

--- a/cgyro/src/cgyro_init_kernel.F90
+++ b/cgyro/src/cgyro_init_kernel.F90
@@ -46,7 +46,10 @@ subroutine cgyro_init_kernel
 
   ! 1. MPI setup
   call cgyro_mpi_grid
-  if (error_status > 0) call cgyro_final_kernel
+  if (error_status > 0) then
+          call cgyro_final_kernel
+          return
+  endif
   
   call system_clock(aftermpi_time,kernel_count_rate,kernel_count_max)
   if (aftermpi_time > kernel_start_time) then
@@ -61,7 +64,10 @@ subroutine cgyro_init_kernel
 
   ! 3. Parameter consistency checks
   call cgyro_check
-  if (error_status > 0) call cgyro_final_kernel
+  if (error_status > 0) then
+          call cgyro_final_kernel
+          return
+  endif
 
   ! 4. Array initialization and construction
   !    NOTE: On exit, field_old = field 


### PR DESCRIPTION
The old reporting was confusing, giving little information.
Also avoid the crash on error.

Fix handling of n_proc_1<n_species for velocity_oder=2... it was completely faulty before.

Add reporting of size of the other two communicators, too.
