### PR TITLE
Add missing HIP synchronize and some memory optimizations

### DIFF
--- a/cgyro/src/cgyro_nl_fftw.gpu.F90
+++ b/cgyro/src/cgyro_nl_fftw.gpu.F90
@@ -62,11 +62,19 @@ subroutine cgyro_nl_fftw
 
   real :: inv_nxny
 
+#ifdef GACODE_GPU_AMD
   ! AMD GPU  (MI250X) optimal
-  integer, parameter :: F_RADTILE = 4
-  integer, parameter :: F_TORTILE = 8
+  integer, parameter :: F_RADTILE = 8
+  integer, parameter :: F_TORTILE = 16
   integer, parameter :: R_RADTILE = 32
-  integer, parameter :: R_TORTILE = 4
+  integer, parameter :: R_TORTILE = 8
+#else
+  ! NVIDIA GPU  (A100) optimal
+  integer, parameter :: F_RADTILE = 8
+  integer, parameter :: F_TORTILE = 16
+  integer, parameter :: R_RADTILE = 16
+  integer, parameter :: R_TORTILE = 8
+#endif
 
   call timer_lib_in('nl_mem')
   ! make sure reqs progress

--- a/platform/build/make.inc.FRONTIER
+++ b/platform/build/make.inc.FRONTIER
@@ -16,9 +16,9 @@ F77 = ${FC}
 
 # Compiler options/flags
 ifneq ($(GACODE_OMPGPU),1)
-FACC   =-hacc -DHIPGPU -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
+FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 else
-FACC = -DOMPGPU -DHIPGPU -I${HIPFORT_DIR}/include/hipfort/amdgcn
+FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn
 endif
 FOMP   =-homp
 FMATH  =-s real64


### PR DESCRIPTION
HIP FFT is asynchronous, so a HIP synchronize is needed. 
The old code was still correct, due to implicit waits in other parts of the code, but doing it explicitly is better.

Also added tiling to NL memory transforms, which gives are 2x-5x speedup in that code sections (but not much difference in total runtime)