### PR TITLE
Introduced user configurable memory specification to qsub

### DIFF
--- a/platform/qsub/qsub.OMEGA
+++ b/platform/qsub/qsub.OMEGA
@@ -6,7 +6,14 @@ echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
 echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
 echo "#SBATCH -t $WALLTIME" >> $bfile
 echo "#SBATCH -n $cores_used" >> $bfile
-echo "#SBATCH --mem 45G" >> $bfile
+
+if [ -n $MEMNODE ] 
+then
+  echo "#SBATCH --mem $MEMNODE" >> $bfile
+elif [ -n $MEMPERCPU ]
+  echo "#SBATCH --mem-per-cpu $MEMPERCPU" >> $bfile
+fi
+
 if [ "$QUEUE" = "null_queue" ]
 then
   echo "#SBATCH -p medium" >> $bfile

--- a/platform/qsub/qsub.PPPL
+++ b/platform/qsub/qsub.PPPL
@@ -6,11 +6,19 @@ echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
 echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
 echo "#SBATCH -t $WALLTIME" >> $bfile
 echo "#SBATCH -n $cores_used" >> $bfile
-echo "#SBATCH --mem=2GB" >> $bfile
+
+if [ -n $MEMNODE ] 
+then
+  echo "#SBATCH --mem $MEMNODE" >> $bfile
+elif [ -n $MEMPERCPU ]
+  echo "#SBATCH --mem-per-cpu $MEMPERCPU" >> $bfile
+fi
+
 if [ "$QUEUE" = "null_queue" ]
 then
   echo "#SBATCH -p general" >> $bfile
 else
   echo "#SBATCH -p $QUEUE" >> $bfile
 fi
+
 echo "$CODE -e $LOCDIR -n $nmpi -nomp $nomp -numa $numa -mpinuma $mpinuma -p $SIMROOT" >> $bfile

--- a/shared/bin/gacode_qsub
+++ b/shared/bin/gacode_qsub
@@ -44,6 +44,14 @@ then
   echo "         -mpinuma <n>" 
   echo "         MPI tasks per active NUMA."
   echo
+  echo "         -mem <n>[unit]" 
+  echo "         -mem-per-cpu <n>[unit]" 
+  echo "         Memory required per node or per cpu, resp."
+  echo "         Default unit MB. Slurm recognizes [K|M|G|T]"
+  echo "         No space beween number and unit."
+  echo "         Precedence is User then -mem"
+  echo "         (default --mem=16GB)."
+  echo
   echo "         -queue"
   echo "         Queue name"
   echo
@@ -95,6 +103,11 @@ nomp=1
 numa=0
 mpinuma=0
 
+#Default Memory Per Node
+MEMPERNODE=16G
+MEMPERCPU=
+USERMPN=false
+
 #=============================================================
 # Parse command line options
 #
@@ -117,6 +130,10 @@ while [[ $# -gt 0 ]] ; do
 
   -numa) shift ; numa=$1 ;;
 
+  -mem) shift ; MEMPERNODE=$1 ; USERMPN=true;;
+
+  -mem-per-cpu) shift ; MEMPERCPU=$1 ;;
+
   -mpinuma) shift ; mpinuma=$1 ;;
 
   -queue) shift ; QUEUE=$1 ;;
@@ -130,7 +147,18 @@ while [[ $# -gt 0 ]] ; do
   esac
   shift
 done
+
 #==============================================================
+# Resolve double specification of memory
+#
+if [[ $USERMPN == true && -n $MEMPERCPU ]]; then
+  echo "WARNING: Both -mem and -mem-per-cpu specified."
+  echo "Applying Precedence -mem=$MEMPERNODE."
+  MEMPERCPU=
+elif [[ $USERMPN == false ]]; then
+  MEMPERNODE=
+fi
+export MEMP
 
 #==============================================================
 # Manage paths


### PR DESCRIPTION
## Introduced User Configurable Memory Specification to `gacode/shared/bin/gacode_qsub`
- Previously it was hardwired in Site Supplemental files in `gacode/platform/qsub`

# Provisioned for `-mem` and `-mem-per-cpu`
## Applied Precedence rules
- Default `-mem=16GB`
- Double specification by user
    - Warning
    - Default to user specified `-mem1
    - Otherwise use use specified values

## Communicates select through environment variables
- MEMPERNODE
- MEMPERCPU
- Logic nullifies other variable

##  Site Supplemental file responds correspondingly

- [x] Modified `gacode/shared/bin/gacode_qsub`
- [x] Modified Site Files
    - [x] `gacode/platform/qsub/qsub.PPPL`
    - [x] `gacode/platform/qsub/qsub.OMEGA`
- [ ] Ran regression tests
    - [ ] Write regression tests to confirm behavior
- [ ] Assess if `gacode/shared/bin/gacode_qsub_multi` needs same medicine
- [ ] Peruse the remaining files in `gacode/shared/bin` to ensure compatibility
- [ ] Peruse the remaining Site Files in `gacode/platform/qsub` to ensure compatibility

I have taken a cursory look at all files and don't see anything glaring, but it deserves more consideration