### PR TITLE
WIP: Revert "Introduced user configurable memory specification to qsub"

### DIFF
--- a/platform/qsub/qsub.OMEGA
+++ b/platform/qsub/qsub.OMEGA
@@ -6,14 +6,7 @@ echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
 echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
 echo "#SBATCH -t $WALLTIME" >> $bfile
 echo "#SBATCH -n $cores_used" >> $bfile
-
-if [ -n $MEMNODE ] 
-then
-  echo "#SBATCH --mem $MEMNODE" >> $bfile
-elif [ -n $MEMPERCPU ]
-  echo "#SBATCH --mem-per-cpu $MEMPERCPU" >> $bfile
-fi
-
+echo "#SBATCH --mem 45G" >> $bfile
 if [ "$QUEUE" = "null_queue" ]
 then
   echo "#SBATCH -p medium" >> $bfile

--- a/platform/qsub/qsub.PPPL
+++ b/platform/qsub/qsub.PPPL
@@ -6,19 +6,11 @@ echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
 echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
 echo "#SBATCH -t $WALLTIME" >> $bfile
 echo "#SBATCH -n $cores_used" >> $bfile
-
-if [ -n $MEMNODE ] 
-then
-  echo "#SBATCH --mem $MEMNODE" >> $bfile
-elif [ -n $MEMPERCPU ]
-  echo "#SBATCH --mem-per-cpu $MEMPERCPU" >> $bfile
-fi
-
+echo "#SBATCH --mem=2GB" >> $bfile
 if [ "$QUEUE" = "null_queue" ]
 then
   echo "#SBATCH -p general" >> $bfile
 else
   echo "#SBATCH -p $QUEUE" >> $bfile
 fi
-
 echo "$CODE -e $LOCDIR -n $nmpi -nomp $nomp -numa $numa -mpinuma $mpinuma -p $SIMROOT" >> $bfile

--- a/shared/bin/gacode_qsub
+++ b/shared/bin/gacode_qsub
@@ -44,14 +44,6 @@ then
   echo "         -mpinuma <n>" 
   echo "         MPI tasks per active NUMA."
   echo
-  echo "         -mem <n>[unit]" 
-  echo "         -mem-per-cpu <n>[unit]" 
-  echo "         Memory required per node or per cpu, resp."
-  echo "         Default unit MB. Slurm recognizes [K|M|G|T]"
-  echo "         No space beween number and unit."
-  echo "         Precedence is User then -mem"
-  echo "         (default --mem=16GB)."
-  echo
   echo "         -queue"
   echo "         Queue name"
   echo
@@ -103,11 +95,6 @@ nomp=1
 numa=0
 mpinuma=0
 
-#Default Memory Per Node
-MEMPERNODE=16G
-MEMPERCPU=
-USERMPN=false
-
 #=============================================================
 # Parse command line options
 #
@@ -130,10 +117,6 @@ while [[ $# -gt 0 ]] ; do
 
   -numa) shift ; numa=$1 ;;
 
-  -mem) shift ; MEMPERNODE=$1 ; USERMPN=true;;
-
-  -mem-per-cpu) shift ; MEMPERCPU=$1 ;;
-
   -mpinuma) shift ; mpinuma=$1 ;;
 
   -queue) shift ; QUEUE=$1 ;;
@@ -147,18 +130,7 @@ while [[ $# -gt 0 ]] ; do
   esac
   shift
 done
-
 #==============================================================
-# Resolve double specification of memory
-#
-if [[ $USERMPN == true && -n $MEMPERCPU ]]; then
-  echo "WARNING: Both -mem and -mem-per-cpu specified."
-  echo "Applying Precedence -mem=$MEMPERNODE."
-  MEMPERCPU=
-elif [[ $USERMPN == false ]]; then
-  MEMPERNODE=
-fi
-export MEMP
 
 #==============================================================
 # Manage paths


### PR DESCRIPTION
Reverts gafusion/gacode#346
> [!WARNING]
>  # WIP

> [!NOTE]
> ## Previous PR was WIP but not Marked.
> # New approach: Memory Defaults are moving to Platform qsubs

## Introduces User Configurable Memory Specification to `gacode/shared/bin/gacode_qsub`
- Previously it was hardwired in Site Supplemental files in `gacode/platform/qsub`

# Provisioned for `-mem` and `-mem-per-cpu`
## Applied Precedence rules
- Default `-mem=16GB`
- Double specification by user
    - Warning
    - Default to user specified `-mem1
    - Otherwise use use specified values

## Communicates select through environment variables
- MEMPERNODE
- MEMPERCPU
- Logic nullifies other variable

##  Site Supplemental file responds correspondingly

- [x] Modified `gacode/shared/bin/gacode_qsub`
- [x] Modified Site Files
    - [x] `gacode/platform/qsub/qsub.PPPL`
    - [x] `gacode/platform/qsub/qsub.OMEGA`
- [ ] Ran regression tests
    - [ ] Write regression tests to confirm behavior
- [ ] Assess if `gacode/shared/bin/gacode_qsub_multi` needs same medicine
- [ ] Peruse the remaining files in `gacode/shared/bin` to ensure compatibility
- [ ] Peruse the remaining Site Files in `gacode/platform/qsub` to ensure compatibility

I have taken a cursory look at all files and don't see anything glaring, but it deserves more consideration