### PR TITLE
Updated platform files for NEURON

### DIFF
--- a/platform/build/make.inc.NEURON
+++ b/platform/build/make.inc.NEURON
@@ -14,12 +14,11 @@ NUMAS_PER_NODE=1
 # Compilers
 
 FC = mpif90 -module ${GACODE_ROOT}/modules -Mpreprocess -DUSE_INLINE
-# -I/apps/compiler/pgi/linux86-64/19.1/cudampi/10.0/openmpi/2.3/applib2/
 F77 = ${FC} 
 
 # Compiler options / flags
 
-FACC = -acc -Minfo=accel -Mcuda=cuda10.0 -ta=nvidia:cc70 -Mcudalib=cufft 
+FACC = -acc -Minfo=accel -Mcuda=cuda11.0 -ta=nvidia:cc80 -Mcudalib=cufft 
 FOMP = -mp -Mstack_arrays
 FMATH = -r8
 FOPT = -fast

--- a/platform/env/env.NEURON
+++ b/platform/env/env.NEURON
@@ -1,2 +1,2 @@
 module purge
-module load pgi/19.1 netcdf/4.6.1 cuda/10.0 cudampi/openmpi-3.1.0 fftw_mpi/3.3.7 python/3.7.1
+module load nvidia_hpc_sdk/22.7 python/3.7.1


### PR DESCRIPTION
- Used nvidia_hpc_sdk compiler for NEURON
- Found that CUDA 11.0 and cc80 worked for NEURON