### PR TITLE
The netcdf available with gcc11 on portal doesn't work.  

### DIFF
--- a/platform/build/make.inc.PPPL_PORTAL
+++ b/platform/build/make.inc.PPPL_PORTAL
@@ -21,11 +21,11 @@ F2PY   = f2py
 FOMP   = -fopenmp
 
 # System math libraries
-LMATH = -L/usr/lib64 -lopenblas $(FFTW_HOME)/lib/libfftw3.a $(FFTW_HOME)/lib/libfftw3_omp.a
+LMATH = -L$(LAPACKHOME)/lib64 -llapack -lblas $(FFTW_HOME)/lib/libfftw3.a $(FFTW_HOME)/lib/libfftw3_omp.a
 FFTW_INC = $(FFTW_HOME)/include
 
 # NetCDF
-NETCDF = -L/usr/pppl/gcc/11.2-pkgs/netcdf-fortran-4.5.4/lib -lnetcdff -L/usr/lib64/hdf -L/usr/pppl/gcc/11.2-pkgs/netcdf-c-4.8.1/lib -lnetcdf -lnetcdf -ldl -lm
+NETCDF = -L$(NETCDF_FORTRAN_HOME)/lib -lnetcdff -L$(HDF5_HOME)/lib -L$(NETCDF_C_HOME)/lib -lnetcdf  -ldl -lm
 NETCDF_INC =${NETCDF_FORTRAN_HOME}/include -I${NETCDF_C_HOME}/include
 
 # Mapping

--- a/platform/env/env.PPPL_PORTAL
+++ b/platform/env/env.PPPL_PORTAL
@@ -1,7 +1,10 @@
+#%Module1.0
 #!/bin/bash
 
-module load gcc/11.2.0 
-module load openmpi/4.1.2
-module load fftw/3.3.10
-module load netcdf-c/4.8.1
-module load netcdf-fortran/4.5.4
+module load gcc/9.3.0
+module load openmpi/4.0.3
+module load fftw/3.3.8
+module load szip/2.1.1
+module load netcdf-c/4.7.3
+module load netcdf-fortran/4.5.2
+module load lapack/3.9.0


### PR DESCRIPTION
This fixes https://github.com/gafusion/OMFIT-source/issues/7013

@jfparisi and @wdeshazer should test this to see if it passes the other tests in GACODE.

Was there a pressing issue for upgrading the compiler version on portal? 

We should open an issue with PPPL about their netcdf not working properly.