### PR TITLE
Make a single call to parallel_lib_rtrans_real

### DIFF
--- a/cgyro/src/cgyro_init_arrays.F90
+++ b/cgyro/src/cgyro_init_arrays.F90
@@ -111,9 +111,7 @@ subroutine cgyro_init_arrays
 !$acc enter data copyin(jvec_c)
 #endif
 
-  do i_field=1,n_field
-     call parallel_lib_rtrans_real(jvec_c(i_field,:,:,:),jvec_v(i_field,:,:,:))
-  enddo
+  call parallel_lib_rtrans_real(jvec_c,jvec_v)
 
   if (nonlinear_flag == 1) then
 !

--- a/cgyro/src/cgyro_mpi_grid.F90
+++ b/cgyro/src/cgyro_mpi_grid.F90
@@ -281,7 +281,7 @@ subroutine cgyro_mpi_grid
 
   ! ni -> nc
   ! nj -> nv  
-  call parallel_lib_init(nc,nv,nt1,nt_loc,nc_loc,nv_loc,NEW_COMM_1)
+  call parallel_lib_init(nc,nv,nt1,nt_loc,n_field,nc_loc,nv_loc,NEW_COMM_1)
 
   nv1 = 1+i_proc_1*nv_loc
   nv2 = (1+i_proc_1)*nv_loc


### PR DESCRIPTION
This is both more efficient, 
and avoids the stack overflow problem when the compiler decides to do a copy of the array slice on the stack.