### PR TITLE
Add platform CONDA_OMPI_GNU

### DIFF
--- a/platform/build/make.inc.CONDA_OMPI_GNU
+++ b/platform/build/make.inc.CONDA_OMPI_GNU
@@ -1,0 +1,41 @@
+# This platform assumes you have the environment fully from conda.
+# It will compile with OpenMPI and gfortran.
+# A single node setup is assumed (e.g. on a laptop, including Mac)
+#
+# Make sure you create a dedicated envoronment, and have
+# at least the following is the packages installed:
+#    conda install -c conda-forge gfortran make python fftw openmpi netcdf4
+# More details in the env file
+
+MAKE = make
+PREFIX = ${CONDA_PREFIX}
+NETCDF_PATH=${PREFIX}
+MF90 = mpif90
+
+# Compilers and flags
+#
+
+FC	= ${MF90} -std=f2008 -fall-intrinsics -I$(GACODE_ROOT)/modules -J$(GACODE_ROOT)/modules -g -I${PREFIX}/include
+F77	= ${MF90} -g 
+
+FMATH	= -fdefault-real-8 -fdefault-double-8
+FOPT	= -O3 -m64
+FDEBUG	= -Wall -fcheck=all -fbacktrace -fbounds-check -O0 -Wextra -finit-real=nan -Wunderflow -ffpe-trap=invalid,zero,overflow
+FBOUND	= -Wall -fbounds-check
+FOMP	= -fopenmp
+
+# System math libraries
+
+LMATH = -L${PREFIX}/lib -lfftw3 -llapack -lblas
+
+NETCDF = -L${PREFIX}/lib -lnetcdff -lnetcdf 
+NETCDF_INC =${PREFIX}/include
+
+# Archive
+
+ARCH = ar cr
+
+ifdef FANN_ROOT
+   # neural net libraries
+   NN_LIB=-L$(GACODE_ROOT)/../neural/ -I$(GACODE_ROOT)/../neural/ -lbrainfuse -L${PREFIX}/lib -lfann
+endif

--- a/platform/env/env.CONDA_OMPI_GNU
+++ b/platform/env/env.CONDA_OMPI_GNU
@@ -1,0 +1,28 @@
+# This platform assumes you have the environment fully from conda.
+# Works on Mac, too.
+#
+# Make sure you create a dedicated envoronment, and have
+# at least the following is the packages installed:
+#    conda install -c conda-forge gfortran make python fftw openmpi netcdf4
+#
+# If you are new to conda, you can get everything setup by getting and running the installer from
+#    https://docs.anaconda.com/miniconda/
+# and then installing in a dedicated environment called "gacode" using the following command:
+#     conda create -n gacode -c conda-forge gfortran make python fftw openmpi netcdf4
+#     conda activate gacode
+# (you will need to do the activate after each login/shell startup)
+#
+if [ "x$GACODE_PLATFORM" != "xCONDA_OMPI_GNU" ]; then 
+   echo "WARNING: Wrong GACODE_PLATFORM! ('$GACODE_PLATFORM' != 'CONDA_OMPI_GNU')" 2>&1
+elif [ "x$GACODE_ROOT" = "x" ]; then
+   echo "WARNING: GACODE_ROOT is not set" 2>&1
+elif [ ! -f $GACODE_ROOT/platform/env/env.CONDA_OMPI_GNU ]; then
+   echo "WARNING: GACODE_ROOT not properly set, cannot find env.CONDA_OMPI_GNU" 2>&1
+fi
+
+if [ ! -f $CONDA_PREFIX/include/fftw3.f03 ]; then
+   echo 'WARNING: Cound not find fftw3.f03 (expected in $CONDA_PREFIX/include/fftw3.f03' 2>&1
+elif [ "x$GACODE_PLATFORM" = "xCONDA_OMPI_GNU" ] && [ -f $GACODE_ROOT/platform/env/env.CONDA_OMPI_GNU ]; then
+   echo "INFO: Welcome to GACODE platform $GACODE_PLATFORM" 2>&1
+fi
+

--- a/platform/exec/exec.CONDA_OMPI_GNU
+++ b/platform/exec/exec.CONDA_OMPI_GNU
@@ -1,0 +1,21 @@
+#!/bin/sh
+# GACODE Parallel execution script
+
+simdir=${1}
+nmpi=${2}
+exec=${3}
+nomp=${4}
+numa=${5}
+mpinuma=${6}
+
+# nmpi = MPI tasks
+# nomp = OpenMP threads per MPI task
+
+cd $simdir
+
+export OMP_NUM_THREADS=$nomp
+export OMP_STACKSIZE=400M
+ 
+echo ">mpirun -np $nmpi $exec"
+mpirun -np $nmpi $exec
+


### PR DESCRIPTION
This is a generic Conda-base platform that should work as-is on any machine.
No abspaths or other assumptions (apart from conda being used)

conda install -c conda-forge gfortran make python fftw openmpi netcdf4
