### PR TITLE
Added config files adapted to Brew libraries for MacOS

### DIFF
--- a/platform/build/make.inc.GFORTRAN_OSX_BREW
+++ b/platform/build/make.inc.GFORTRAN_OSX_BREW
@@ -1,0 +1,37 @@
+#---------------------------------------------------
+# OSX,gfortran+openmpi from Homebrew
+# 
+# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# brew install gcc open-mpi netcdf netcdf-fortran fftw
+#---------------------------------------------------
+
+IDENTITY="OSX gfortran+openmpi from Homebrew"
+
+MAKE = make
+
+MF90 = mpif90
+
+# Compilers and flags
+
+FC  = ${MF90} -std=f2008 -fall-intrinsics -I$(FFTW_INC) -I$(GACODE_ROOT)/modules -J$(GACODE_ROOT)/modules -I/opt/local/include -fPIC
+F77 = ${MF90} -w -fallow-argument-mismatch
+
+FOMP	= -fopenmp
+FMATH	= -fdefault-real-8 -fdefault-double-8
+FOPT	= -O3 -m64 -framework Accelerate
+FDEBUG	= -Wall -g -fcheck=all -fbacktrace -fbounds-check -O0 -Wextra -finit-real=nan -Wunderflow -ffpe-trap=invalid,zero,overflow
+#F2PY    = f2py-2.7
+
+# System libraries
+
+LMATH = -L$(BREW_LIB) -lfftw3
+NETCDF = -L$(BREW_LIB) -lnetcdff -lnetcdf
+
+# Archive
+
+ARCH = ar cr
+
+ifdef FANN_ROOT
+   # neural net libraries
+   NN_LIB=-L$(GACODE_ROOT)/../neural/ -I$(GACODE_ROOT)/../neural/ -lbrainfuse -lfann
+endif

--- a/platform/env/env.GFORTRAN_OSX_BREW
+++ b/platform/env/env.GFORTRAN_OSX_BREW
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export BREW_LIB=$(brew --prefix)/lib
+export LD_LIBRARY_PATH=$(brew --prefix)/lib:$LD_LIBRARY_PATH
+export FFTW_INC=$(brew --prefix fftw)/include
+export NETCDF_INC=$(brew --prefix netcdf)/include

--- a/platform/exec/exec.GFORTRAN_OSX_BREW
+++ b/platform/exec/exec.GFORTRAN_OSX_BREW
@@ -1,0 +1,17 @@
+#!/bin/sh
+# GACODE Parallel execution script (GFORTRAN_OSX_MACPORTS)
+#
+# NOTES:
+# Used mpich2-1.0.3, so use mpirun rather than mpiexec
+
+simdir=${1}
+nmpi=${2}
+exec=${3}
+nomp=${4}
+numa=${5}
+mpinuma=${6}
+
+echo $simdir
+
+cd $simdir
+export OMP_NUM_THREADS=$nomp ; mpiexec --oversubscribe -np $nmpi $exec


### PR DESCRIPTION
Dear Gacode maintainers,

trying to build the code on my personal Macbook, I have found that it can be built also using external libraries installed via Homebrew, instead of from MacPorts. Or, at the very least, the compilation runs smoothly, as well as the basic regression tests.
Since some people (like myself) may prefer using Homebrew instead of MacPorts to manage the external libraries, I took the freedom to add the configuration files needed for this.
In case the PR is accepted, it might be worth to update the [related documentation](https://gafusion.github.io/doc/build/pre_osx.html) as well (I don't know where its source code is), to add this alternative possibility.
What needs to be done beforehand is as simple as 
`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
(to install Homebrew, in case it is still not installed), and
`brew install gcc open-mpi netcdf netcdf-fortran fftw`
to install the required dependencies.