### PR TITLE
Added platform files for MIT Engaging cluster

### DIFF
--- a/platform/build/make.inc.ENGAGING_ROCKY8
+++ b/platform/build/make.inc.ENGAGING_ROCKY8
@@ -1,0 +1,50 @@
+#---------------------------------------------------
+# PSFC Engaging Cluster (orcd-login###.mit.edu) [GCC]
+#
+#   export GACODE_ROOT=<top_of_cloned_repo>
+#   export GACODE_PLATFORM=ENGAGING_ROCKY8
+#   source ${GACODE_ROOT}/platform/env/env.${GACODE_PLATFORM}
+#   source ${GACODE_ROOT}/shared/bin/gacode_setup
+#
+#---------------------------------------------------
+
+#  FIXED Hardware parameters
+CORES_PER_NODE=64
+NUMAS_PER_NODE=1
+
+MAKE           := make
+LIB_PATH       := $(subst :, ,${CMAKE_PREFIX_PATH})
+OPENBLAS_PATH  := $(strip $(foreach x,${LIB_PATH},$(if $(findstring openblas,${x}),${x})))
+FFTW_PATH      := $(strip $(foreach x,${LIB_PATH},$(if $(findstring fftw,${x}),${x})))
+HDF5_PATH      := $(strip $(foreach x,${LIB_PATH},$(if $(findstring hdf5,${x}),${x})))
+NETCDF_PATH    := $(strip $(foreach x,${LIB_PATH},$(if $(findstring netcdf-c,${x}),${x})))
+NETCDFF_PATH   := $(strip $(foreach x,${LIB_PATH},$(if $(findstring netcdf-fortran,${x}),${x})))
+LIB_PATH       := $(filter-out ${OPENBLAS_PATH} ${FFTW_PATH} ${NETCDF_PATH},${LIB_PATH})
+LIB            := $(foreach x,${LIB_PATH},-L$(strip ${x})/lib)
+INCLUDE        := -I/usr/include $(foreach x,${LIB_PATH},-I$(strip ${x})/include) -I${OPENBLAS_PATH}/include -I${FFTW_PATH}/include
+MF90           := mpif90
+
+# Compilers and flags
+
+FC     = ${MF90} -std=f2008 -fall-intrinsics -fPIC -I$(GACODE_ROOT)/modules -J$(GACODE_ROOT)/modules -g ${INCLUDE} ${LIB}
+F77    = ${MF90} -g
+
+FMATH  = -fdefault-real-8 -fdefault-double-8
+FOPT   = -O3 -fallow-argument-mismatch
+FDEBUG = -Wall -fcheck=all -fbacktrace -fbounds-check -O0 -Wextra -finit-real=nan -Wunderflow -ffpe-trap=invalid,zero,overflow
+FBOUND = -Wall -fbounds-check
+FOMP   = -fopenmp
+
+# System math libraries
+
+LMATH = -L${OPENBLAS_PATH} -lopenblas -L${FFTW_PATH}/lib -lfftw3 -lfftw3f -lfftw3_threads -lfftw3f_threads
+
+# Optional netCDF libraries
+
+NETCDF     = -L${NETCDFF_PATH}/lib -lnetcdff -L${NETCDF_PATH}/lib -lnetcdf -L${HDF5_PATH}/lib -lhdf5 -lhdf5_hl
+NETCDF_INC = ${NETCDFF_PATH}/include
+
+# Archive
+
+ARCH = ar cr
+

--- a/platform/build/make.inc.ENGAGING_ROCKY8
+++ b/platform/build/make.inc.ENGAGING_ROCKY8
@@ -1,5 +1,5 @@
 #---------------------------------------------------
-# PSFC Engaging Cluster (orcd-login###.mit.edu) [GCC]
+# MIT Engaging Cluster (orcd-login###.mit.edu) [GCC]
 #
 #   export GACODE_ROOT=<top_of_cloned_repo>
 #   export GACODE_PLATFORM=ENGAGING_ROCKY8

--- a/platform/env/env.ENGAGING_ROCKY8
+++ b/platform/env/env.ENGAGING_ROCKY8
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+module purge
+module load gcc/12.2.0
+module load openmpi/4.1.4
+module load openblas/0.3.26
+module load fftw/3.3.10
+module load community-modules
+module load hdf5/1.14.3
+module load netcdf-c/4.9.2
+module load netcdf-fortran/4.6.1
+module load miniforge/24.3.0-0
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/orcd/software/core/001/spack/pkg/gcc/12.2.0/yt6vabm/lib:/orcd/software/core/001/spack/pkg/openmpi/4.1.4/zahpnmk/lib:/orcd/software/core/001/spack/pkg/openblas/0.3.26/ro5tivv/lib:/orcd/software/core/001/spack/pkg/fftw/3.3.10/dg7y4ph/lib:/orcd/software/community/001/spack/pkg/netcdf-c/4.9.2/2uroesk/lib:/orcd/software/community/001/spack/pkg/netcdf-fortran/4.6.1/gxllmsl/lib:/orcd/software/community/001/spack/pkg/hdf5/1.14.3/suffu3v/lib

--- a/platform/exec/exec.ENGAGING_ROCKY8
+++ b/platform/exec/exec.ENGAGING_ROCKY8
@@ -1,0 +1,19 @@
+#!/bin/sh
+# GACODE Parallel execution script (ENGAGING)
+#
+# NOTES:
+# Used openmpi-4.1.4
+
+simdir=${1}
+nmpi=${2}
+exec=${3}
+nomp=${4}
+numa=${5}
+mpinuma=${6}
+
+echo $simdir
+
+cd $simdir
+ 
+mpirun -x OMP_NUM_THREADS=$nomp -np $nmpi --oversubscribe $exec
+

--- a/platform/qsub/qsub.ENGAGING_ROCKY8
+++ b/platform/qsub/qsub.ENGAGING_ROCKY8
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "-queue: sched_mit_psfc_r8"
+
+# Default queue
+if [ "$QUEUE" == "null_queue" ] ; then
+   QUEUE=sched_mit_psfc_r8
+fi
+
+bfile=$SIMDIR/batch.src
+
+echo "#!/bin/bash -l" > $bfile
+echo "#SBATCH -J $LOCDIR" >> $bfile
+echo "#SBATCH -o $SIMDIR/batch.out" >> $bfile
+echo "#SBATCH -e $SIMDIR/batch.err" >> $bfile
+echo "#SBATCH -p $QUEUE" >> $bfile
+echo "#SBATCH -t $WALLTIME" >> $bfile
+echo "#SBATCH -N $nodes" >> $bfile
+echo "#SBATCH -n $cores_used" >> $bfile
+
+echo "$CODE -e $LOCDIR -n $nmpi -p $SIMROOT" >> $bfile 

--- a/platform/qsub/qsub.ENGAGING_ROCKY8
+++ b/platform/qsub/qsub.ENGAGING_ROCKY8
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "-queue: sched_mit_psfc_r8"
+echo "-queue: mit_normal"
 
 # Default queue
 if [ "$QUEUE" == "null_queue" ] ; then


### PR DESCRIPTION
- Instructions only work on the Rocky 8 nodes
- MIT plans to sunset the CentOS 7 nodes so support will not be provided there (missing single precision FFTW library)