### PR TITLE
Deprecate gpu_bigmem_flag>1, treat as ==1

### DIFF
--- a/cgyro/src/cgyro_check_memory.F90
+++ b/cgyro/src/cgyro_check_memory.F90
@@ -195,7 +195,7 @@ subroutine cgyro_check_memory(datafile)
            call cgyro_alloc_add_4d(io,nv,nv,nc_loc_coll,nt_loc,8,'cmat')
         endif
 #if defined(OMPGPU) || defined(_OPENACC)
-        if (gpu_bigmem_flag /= 1) then
+        if (gpu_bigmem_flag == 0) then
            write(io,*) 'Note: cmat is not in GPU memory'
         endif
 #endif

--- a/cgyro/src/cgyro_cleanup.F90
+++ b/cgyro/src/cgyro_cleanup.F90
@@ -13,14 +13,14 @@ subroutine cgyro_cleanup
 #define ccl_del_device(x) \
 !$omp target exit data map(release:x)
 #define ccl_del_bigdevice(x) \
-!$omp target exit data map(release:x) if (gpu_bigmem_flag == 1)
+!$omp target exit data map(release:x) if (gpu_bigmem_flag > 0)
 
 #elif defined(_OPENACC)
 
 #define ccl_del_device(x) \
 !$acc exit data delete(x)
 #define ccl_del_bigdevice(x) \
-!$acc exit data delete(x) if (gpu_bigmem_flag == 1)
+!$acc exit data delete(x) if (gpu_bigmem_flag > 0)
 
 #else
 

--- a/cgyro/src/cgyro_init_collision.F90
+++ b/cgyro/src/cgyro_init_collision.F90
@@ -827,9 +827,9 @@ subroutine cgyro_init_collision
   if (collision_precision_mode == 1) then
 #if defined(OMPGPU)
      ! no async for OMPGPU for now
-!$omp target enter data map(to:cmat_fp32,cmat_stripes,cmat_e1) if (gpu_bigmem_flag == 1)
+!$omp target enter data map(to:cmat_fp32,cmat_stripes,cmat_e1) if (gpu_bigmem_flag > 0)
 #elif defined(_OPENACC)
-!$acc enter data copyin(cmat_fp32,cmat_stripes,cmat_e1) async if (gpu_bigmem_flag == 1)
+!$acc enter data copyin(cmat_fp32,cmat_stripes,cmat_e1) async if (gpu_bigmem_flag > 0)
 #endif
      call MPI_ALLREDUCE(cmap_fp32_error_abs_cnt_loc,&
           cmap_fp32_error_abs_cnt,&
@@ -900,15 +900,15 @@ subroutine cgyro_init_collision
 #endif
   else if (collision_precision_mode == 32) then
 #if defined(OMPGPU)
-!$omp target enter data map(to:cmat_fp32) if (gpu_bigmem_flag == 1)
+!$omp target enter data map(to:cmat_fp32) if (gpu_bigmem_flag > 0)
 #elif defined(_OPENACC)
-!$acc enter data copyin(cmat_fp32) if (gpu_bigmem_flag == 1)
+!$acc enter data copyin(cmat_fp32) if (gpu_bigmem_flag > 0)
 #endif
   else
 #if defined(OMPGPU)
-!$omp target enter data map(to:cmat) if (gpu_bigmem_flag == 1)
+!$omp target enter data map(to:cmat) if (gpu_bigmem_flag > 0)
 #elif defined(_OPENACC)
-!$acc enter data copyin(cmat) if (gpu_bigmem_flag == 1)
+!$acc enter data copyin(cmat) if (gpu_bigmem_flag > 0)
 #endif
   endif
 


### PR DESCRIPTION
The "partial GPU cmat offload" was typically slower than the other two alternatives.
No good reason to keep maintaining the code in the long term.
If anyone is using gpu_bigmem_flag>1, it will default to normal GPU offload now.
