### PR TITLE
Fix for Cray compilers in OMPGPU mode

### DIFF
--- a/platform/build/make.inc.COSMOS_SPX
+++ b/platform/build/make.inc.COSMOS_SPX
@@ -19,7 +19,7 @@ F77 = ${FC}
 ifneq ($(GACODE_OMPGPU),1)
 FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 else
-FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn
+FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 endif
 FOMP   =-homp
 FMATH  =-s real64

--- a/platform/build/make.inc.COSMOS_TPX
+++ b/platform/build/make.inc.COSMOS_TPX
@@ -19,7 +19,7 @@ F77 = ${FC}
 ifneq ($(GACODE_OMPGPU),1)
 FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 else
-FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn
+FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 endif
 FOMP   =-homp
 FMATH  =-s real64

--- a/platform/build/make.inc.FRONTIER
+++ b/platform/build/make.inc.FRONTIER
@@ -18,7 +18,7 @@ F77 = ${FC}
 ifneq ($(GACODE_OMPGPU),1)
 FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 else
-FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn
+FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 endif
 FOMP   =-homp
 FMATH  =-s real64

--- a/platform/build/make.inc.LUMI
+++ b/platform/build/make.inc.LUMI
@@ -18,7 +18,7 @@ F77 = ${FC}
 ifneq ($(GACODE_OMPGPU),1)
 FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 else
-FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn
+FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 endif
 FOMP   =-homp
 FMATH  =-s real64


### PR DESCRIPTION
Cray compilers default to 32-bit pointer arithmetic on the GPUs, which results in wrong results with large buffers.
That's especially problematic for cmat, which can be really big.
The right flag (no_fast_addr) was already used for OpenACC< but was missing from OMPGPU builds.

Cray docs:
https://cpe.ext.hpe.com/docs/latest/getting_started/CPE-CCE-Fortran.html