### PR TITLE
Add DISABLE_CMAT_INIT_OMP support

### DIFF
--- a/cgyro/src/cgyro_init_collision.F90
+++ b/cgyro/src/cgyro_init_collision.F90
@@ -476,6 +476,7 @@ subroutine cgyro_init_collision
   cmat_diff_global_loc = 0.0
   cmat32_diff_global_loc = 0.0
 
+#ifndef DISABLE_CMAT_INIT_OMP
 !$omp  parallel do collapse(2) default(none) &
 !$omp& shared(nc_cl1,nc_cl2,nt1,nt2,nv,delta_t,n_species,rho,is_ele,n_field,n_energy,n_xi) &
 !$omp& shared(collision_kperp,collision_field_model,explicit_trap_flag) &
@@ -497,6 +498,7 @@ subroutine cgyro_init_collision
 !$omp& shared(cmat,cmat_fp32,cmat_stripes,cmat_e1) &
 !$omp& reduction(+:cmat_diff_global_loc,cmat32_diff_global_loc) &
 !$omp& reduction(+:cmap_fp32_error_abs_cnt_loc,cmap_fp32_error_rel_cnt_loc)
+#endif
   do itor=nt1,nt2
      do ic=nc_cl1,nc_cl2
 

--- a/platform/build/make.inc.COSMOS_SPX
+++ b/platform/build/make.inc.COSMOS_SPX
@@ -21,7 +21,7 @@ FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn 
 else
 FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 endif
-FOMP   =-homp
+FOMP   =-homp -DDISABLE_CMAT_INIT_OMP=1
 FMATH  =-s real64
 FOPT   =-Ofast
 FDEBUG =-O1 -g -h bounds

--- a/platform/build/make.inc.COSMOS_TPX
+++ b/platform/build/make.inc.COSMOS_TPX
@@ -21,7 +21,7 @@ FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn 
 else
 FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 endif
-FOMP   =-homp
+FOMP   =-homp -DDISABLE_CMAT_INIT_OMP=1
 FMATH  =-s real64
 FOPT   =-Ofast
 FDEBUG =-O1 -g -h bounds

--- a/platform/exec/wrap.COSMOS_SPX
+++ b/platform/exec/wrap.COSMOS_SPX
@@ -4,7 +4,7 @@
 export MPICH_GPU_SUPPORT_ENABLED=1
 
 # disable "smart" Cray BLAS
-export CRAYBLAS_LEVEL3_LEGACY=1
+#export CRAYBLAS_LEVEL3_LEGACY=1
 
 #env 1>&2
 

--- a/platform/exec/wrap.COSMOS_TPX
+++ b/platform/exec/wrap.COSMOS_TPX
@@ -5,6 +5,9 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 
 #env 1>&2
 
+# disable "smart" Cray BLAS
+#export CRAYBLAS_LEVEL3_LEGACY=1
+
 #echo $SLURM_LOCALID
 let r4=SLURM_LOCALID/12
 let l4="$SLURM_LOCALID-($r4*12)"


### PR DESCRIPTION
If DISABLE_CMAT_INIT_OMP is set, do not use OpenMP in cgyro_init_collision.
This may be needed if a OMP-enabled BLAS library is used, as it may conflict with the external OMP loop.
Not ideal, as it makes things significantly slower during init_collision, but since that is only run once, it can be a usable workaround when everything else fails.
