### PR TITLE
Restore functional version of the filtering logic presented in: Najlaoui et al., Plasma Phys. Control. Fusion, 67(4), 045016 (2025)

### DIFF
--- a/tglf/src/tglf_LS.f90
+++ b/tglf/src/tglf_LS.f90
@@ -35,7 +35,6 @@
       INTEGER,ALLOCATABLE,DIMENSION(:) :: ipiv
       COMPLEX,ALLOCATABLE,DIMENSION(:,:) :: zmat
 !  Filter numerical instabilities
-      logical :: is_odd
       logical :: is_even
       INTEGER :: nb_of_unstable_modes
       REAL :: total_weight, odd_weight, ratio_odd
@@ -269,17 +268,16 @@ if(new_matrix)then
 
 
       ! ============================================================================
-      ! Filter out unphysical numerical instabilities based on mode parity and frequency
+      ! Filter out unphysical numerical instabilities
+      ! based on mode parity and frequency  (Najlaoui et al. PPCF 2025)
       ! This filter is only active when FILTER < 0
       !
       ! Logic summary:
-      !   - Estimate mode parity using Hermite basis decomposition
-      !   - If the mode is not odd --> keep it
-      !   - If the mode is odd:
-      !       - If |FILTER| <= 0.1 --> remove it systematically
-      !       - Else:
-      !           - If |omega_r| > |FILTER * omega_DW| --> remove it
-      !           - Else --> keep it
+      !   - Check if |omega_r| > |FILTER * omega_DW|
+      !       - If not: keep the mode
+      !       - If yes:
+      !           - Keep only if Re[phi] is EVEN and omega_r is in ion diamagnetic direction
+      !           - Otherwise: remove the mode
       ! ============================================================================
       if (filter_in.lt.0.0) then
         nb_of_unstable_modes = 0
@@ -292,7 +290,6 @@ if(new_matrix)then
 
         do imax = 1, MIN(nb_of_unstable_modes,maxmodes)
           is_even = .false.
-          is_odd  = .false.
 
           if (jmax(imax) > 0) then
             ! Solve the linear system to reconstruct eigenvector
@@ -322,11 +319,11 @@ if(new_matrix)then
             !     ratio_odd = sum over even j  [ Im(field_weight(j))^2 ] /
             !                 sum over all j   [ Im(field_weight(j))^2 ]
             !
-            ! If ratio_odd > 0.85, the mode is classified as "odd-parity"
+            ! If ratio_odd < 0.2, the mode is classified as "even-parity"
             ! This method is more robust than checking symmetry of phi(theta)
             ! because it uses the known parity of the basis functions directly
             !
-            ! NOTE: The threshold (0.85) can be tuned to be more or less conservative
+            ! NOTE: The threshold (0.2) can be tuned to be more or less conservative
             ! ------------------------------------------------------------------------
             ratio_odd = 0.0
             total_weight = 0.0
@@ -341,32 +338,17 @@ if(new_matrix)then
 
             if (total_weight > 0.0) then
               ratio_odd = odd_weight / total_weight
-              if (ratio_odd > 0.85) is_odd = .true.
+              if (ratio_odd < 0.2) is_even = .true.
             end if
 
             ! ------------------------------------------------------------------------
-            ! FILTERING LOGIC
+            ! FILTERING LOGIC (Najlaoui et al. PPCF 2025)
             ! ------------------------------------------------------------------------
-            ! Logic:
-            !   - If the mode is NOT odd (even or undetermined): KEEP
-            !   - If the mode is odd:
-            !        - If |FILTER| <= 0.1 : always REMOVE odd modes
-            !        - Else:
-            !            - If |omega_r| > |FILTER * omega_DW| : REMOVE
-            !            - Else : KEEP
-            ! ------------------------------------------------------------------------
-            if (is_odd) then
-              if (ABS(filter_in) <= 0.1) then
-                rr(jmax(imax)) = 0.0
-
-              else if (ABS(ri(jmax(imax))) > ABS(max_freq)) then
-                rr(jmax(imax)) = 0.0
-
-              else
-                ! Odd parity, frequency low : keep mode
+            if (ABS(ri(jmax(imax))) > ABS(max_freq)) then
+              ! Inside condition: keep only even-parity modes propagating in ion direction
+              if (.not.(is_even .and. ri(jmax(imax)) > 0.0)) then
+                rr(jmax(imax)) = 0.0  ! Remove mode
               end if
-            else
-              ! Mode not identified as odd : keep by default
             end if
           end if
         end do


### PR DESCRIPTION
This commit restores the filtering logic presented in:
Najlaoui et al., Plasma Phys. Control. Fusion, 67(4), 045016 (2025)

The previous implementation was not working correctly. This version fixes several issues:
- The code now follow the intended filtering logic
- All unstable modes are now considered (not just the first two)
- Modes to be filtered are now properly excluded (gamma set to 0)
- The parity detection has been highly improved using Hermite basis decomposition

Logic:
- Keep all low-frequency modes
- For high-frequency modes (|omega_r| > |FILTER * omega_DW|): Keep only if mode is even-parity and propagates in the ion diamagnetic drift direction (omega_r > 0)