### PR TITLE
Sat3 NaN fix

### DIFF
--- a/tglf/src/tglf_multiscale_spectrum.f90
+++ b/tglf/src/tglf_multiscale_spectrum.f90
@@ -268,7 +268,9 @@
           jmax_out = jmax_mix
         else
           vzf_out_fp = vzf_out ! used for recreation of first pass for SAT3
-          vzf_out = vzf_out*gamma_net(jmax_out)/MAX(eigenvalue_spectrum_out(1,jmax_out,1),small)
+          if(gamma_net(jmax_out)/=0.0)then
+           vzf_out = vzf_out*gamma_net(jmax_out)/MAX(eigenvalue_spectrum_out(1,jmax_out,1),small)
+          endif
         endif
 !        write(*,*)"2nd PASS: vzf_out = ",vzf_out,"  jmax_out = ",jmax_out
 !        write(*,*)"2nd PASS: kymax_out = ",kymax_out,"  gammamax_out = ",kymax_out*vzf_out

--- a/tglf/src/tglf_multiscale_spectrum.f90
+++ b/tglf/src/tglf_multiscale_spectrum.f90
@@ -268,9 +268,7 @@
           jmax_out = jmax_mix
         else
           vzf_out_fp = vzf_out ! used for recreation of first pass for SAT3
-          if(gamma_net(jmax_out)/=0.0)then
-           vzf_out = vzf_out*gamma_net(jmax_out)/MAX(eigenvalue_spectrum_out(1,jmax_out,1),small)
-          endif
+          vzf_out = vzf_out*gamma_net(jmax_out)/MAX(eigenvalue_spectrum_out(1,jmax_out,1),small)
         endif
 !        write(*,*)"2nd PASS: vzf_out = ",vzf_out,"  jmax_out = ",jmax_out
 !        write(*,*)"2nd PASS: kymax_out = ",kymax_out,"  gammamax_out = ",kymax_out*vzf_out
@@ -343,7 +341,11 @@
        if(ky0.lt.kymax1)then
         gamma(j) = gamma0
        else
-        gamma(j) = (gammamax1 * (vzf_out_fp/vzf_out)) + Max(gamma0 - cz2*vzf_out_fp*ky0,0.0)
+        if(vzf_out==0.0)then
+         gamma(j) = gammamax1 + Max(gamma0 - cz2*vzf_out_fp*ky0,0.0)
+        else
+         gamma(j) = (gammamax1 * (vzf_out_fp/vzf_out)) + Max(gamma0 - cz2*vzf_out_fp*ky0,0.0)
+        endif
        endif
        gamma_fp(j) = gamma(j)
       enddo


### PR DESCRIPTION
NaNs can appear for SAT3 when `gamma_net(jmax_out)` is zero due to it being used in the definition of `vzf_out` in the second pass of the spectral shift model, as a division by `vzf_out` occurs in the construction of `gamma(j)`. 
https://github.com/gafusion/gacode/blob/f656eb4413a121c95cb2daf23f68d31928bcd6e0/tglf/src/tglf_multiscale_spectrum.f90#L271
https://github.com/gafusion/gacode/blob/f656eb4413a121c95cb2daf23f68d31928bcd6e0/tglf/src/tglf_multiscale_spectrum.f90#L344
This PR fixes this issue by only including the division in the calculation when `gamma_net(jmax_out)` is nonzero. When it's zero, the division is redundant anyway as `gammamax1` is also zero, from
https://github.com/gafusion/gacode/blob/f656eb4413a121c95cb2daf23f68d31928bcd6e0/tglf/src/tglf_multiscale_spectrum.f90#L281