### PR TITLE
update ballooning parsing with actual time step

### DIFF
--- a/f2py/pygacode/cgyro/data.py
+++ b/f2py/pygacode/cgyro/data.py
@@ -105,27 +105,40 @@ class cgyrodata:
       #-----------------------------------------------------------------
 
       #-----------------------------------------------------------------
-      # Ballooning potentials
+      # Ballooning potentials (phib, aparb, bparb)
+      #
+      # Fix for interrupted runs: Calculate actual time steps from
+      # binary file size rather than ASCII metadata to handle cases where
+      # wallclock limits cause runs to terminate before completion
       #
       nd = 2*self.n_theta*self.n_radial*nt
       f='.cgyro.phib'
       t,fmt,data = self.extract(f,cmplx=True)
       if fmt != 'null':
-         self.phib = np.reshape(data,(self.n_theta*self.n_radial,nt),'F')
+         # Calculate actual time steps from data size (handles interrupted runs)
+         spatial_size = self.n_theta*self.n_radial
+         actual_nt = len(data) // spatial_size
+         self.phib = np.reshape(data,(spatial_size,actual_nt),'F')
          if not self.silent:
             print('INFO: (getdata) Read data in '+fmt+f+'  '+t)
 
       f='.cgyro.aparb'
       t,fmt,data = self.extract(f,cmplx=True)
       if fmt != 'null':
-         self.aparb = np.reshape(data,(self.n_theta*self.n_radial,nt),'F')
+         # Calculate actual time steps from data size (handles interrupted runs)
+         spatial_size = self.n_theta*self.n_radial
+         actual_nt = len(data) // spatial_size
+         self.aparb = np.reshape(data,(spatial_size,actual_nt),'F')
          if not self.silent:
             print('INFO: (getdata) Read data in '+fmt+f+' '+t)
 
       f='.cgyro.bparb'
       t,fmt,data = self.extract(f,cmplx=True)
       if fmt != 'null':
-         self.bparb = np.reshape(data,(self.n_theta*self.n_radial,nt),'F')
+         # Calculate actual time steps from data size (handles interrupted runs)
+         spatial_size = self.n_theta*self.n_radial
+         actual_nt = len(data) // spatial_size
+         self.bparb = np.reshape(data,(spatial_size,actual_nt),'F')
          if not self.silent:
             print('INFO: (getdata) Read data in '+fmt+f+' '+t)
       #-----------------------------------------------------------------


### PR DESCRIPTION
When linear CGYRO runs are interrupted by wall clock time limits, the number of time steps in the ballooning binary data files (`bin.cgyro.phib`, `bin.cgyro.aparb`, `bin.cgyro.bparb`) can differ from the time steps recorded in the ASCII metadata file (`out.cgyro.time`). This causes reshape errors when the parser tries to use the ASCII metadata to reshape the binary data.

Solution: Calculate the actual number of time steps directly from the binary file size rather than relying on ASCII metadata.

Files changed:
- `f2py/pygacode/cgyro/data.py`: Use dynamic time step calculation for ballooning data

Testing: Verified with both completed runs and interrupted runs that previously failed with reshape errors.