### PR TITLE
Fixed build settings for Aurora at ALCF

### DIFF
--- a/platform/build/make.inc.AURORA
+++ b/platform/build/make.inc.AURORA
@@ -8,11 +8,17 @@ CORES_PER_NODE=204
 NUMAS_PER_NODE=12
 
 # Compilers and flags
-FC     = mpif90 -gen-interfaces -module ${GACODE_ROOT}/modules -I${GACODE_ROOT}/module -allow nofpp-comments
+FC     = mpif90 -gen-interfaces -module ${GACODE_ROOT}/modules -I${GACODE_ROOT}/modules -allow nofpp-comments
 F77    = ${FC}
 
-FOMP   = -fiopenmp -fopenmp-targets=spir64 -DOMPGPU -DMKLGPU
+FOMP      = -fiopenmp -fopenmp-targets=spir64 -DOMPGPU -DMKLGPU
+
+# For legacy fixed-form Fortran (.f, .for)
+FMATH_FIXED     = -real-size 64 -qmkl=parallel -I${TACC_MKL_INC}/
+
+# For preprocessed/free-form sources only (.F, .F90, selected files)
 FMATH  = -real-size 64 -qmkl=parallel -fpp -free -I${TACC_MKL_INC}/
+
 # Note: -Ofast produces bad results
 FOPT   = -g -O2
 FDEBUG = -eD -Ktrap=fp -m 1

--- a/shared/nclass/Makefile
+++ b/shared/nclass/Makefile
@@ -25,7 +25,7 @@ lib: $(OBJECTS)
 	$(ARCH) $(LLIB).a $(OBJECTS)
 
 .f.o :
-	$(F77) $(FMATH) $(FFLAGS) -c $<
+	$(F77) $(FMATH_FIXED) $(FFLAGS) -c $<
 
 clean:
 	rm -rf *.o nclass_lib.a *~


### PR DESCRIPTION
I ran into some issues building `gacode` on Aurora, particularly the F77 sources of `nclass`. The variable `FMATH` used an option for free-form Fortran, which did not like `#` as line continuation character. I introduced a separate variable `FMATH_FIXED` to address this.

Since `FMATH_FIXED` is currently defined only in the build setup for Aurora, this will probably break other builds. Please advise how to make this fix more general, or feel free to take over this PR to implement a clean solution.