### PR TITLE
Fixes needed to use latest compiler on Frontier

### DIFF
--- a/cgyro/src/cgyro_cleanup.F90
+++ b/cgyro/src/cgyro_cleanup.F90
@@ -8,46 +8,36 @@ subroutine cgyro_cleanup
 #define CGYRO_GPU_FFT
 #endif
 
-#if defined(OMPGPU)
-
-#define ccl_del_device(x) \
-!$omp target exit data map(release:x)
-#define ccl_del_bigdevice(x) \
-!$omp target exit data map(release:x) if (gpu_bigmem_flag > 0)
-
-#elif defined(_OPENACC)
-
-#define ccl_del_device(x) \
-!$acc exit data delete(x)
-#define ccl_del_bigdevice(x) \
-!$acc exit data delete(x) if (gpu_bigmem_flag > 0)
-
-#else
-
-  ! nothing to do
-#define ccl_del_device(x)
-#define ccl_del_bigdevice(x)
-
-#endif
-
   !!!!!!!!!!!!!!!!!!!!!!!!!!
   ! From cgyro_init_manager
   !!!!!!!!!!!!!!!!!!!!!!!!!!
   
   if(allocated(energy))        deallocate(energy)
   if(allocated(vel))        then
-     ccl_del_device(vel)
+#if defined(OMPGPU)
+!$omp target exit data map(release:vel)
+#elif defined(_OPENACC)
+!$acc exit data delete(vel)
+#endif
      deallocate(vel)
   endif
   if(allocated(vel2))        then
-     ccl_del_device(vel2)
+#if defined(OMPGPU)
+!$omp target exit data map(release:vel2)
+#elif defined(_OPENACC)
+!$acc exit data delete(vel2)
+#endif
      deallocate(vel2)
   endif
   if(allocated(w_e))           deallocate(w_e)
   if(allocated(e_deriv1_mat))  deallocate(e_deriv1_mat)
   if(allocated(e_deriv1_rot_mat))  deallocate(e_deriv1_rot_mat)
   if(allocated(xi))            then
-     ccl_del_device(xi)
+#if defined(OMPGPU)
+!$omp target exit data map(release:xi)
+#elif defined(_OPENACC)
+!$acc exit data delete(xi)
+#endif
      deallocate(xi)
   endif
   if(allocated(w_xi))          deallocate(w_xi)
@@ -70,7 +60,11 @@ subroutine cgyro_cleanup
   if(allocated(captheta))       deallocate(captheta)
   if(allocated(itp))            deallocate(itp)
   if(allocated(omega_stream))   then
-     ccl_del_device(omega_stream)
+#if defined(OMPGPU)
+!$omp target exit data map(release:omega_stream)
+#elif defined(_OPENACC)
+!$acc exit data delete(omega_stream)
+#endif
      deallocate(omega_stream)
   endif
   if(allocated(omega_trap))          deallocate(omega_trap)
@@ -97,27 +91,51 @@ subroutine cgyro_cleanup
   if(allocated(gtime))               deallocate(gtime)
   if(allocated(freq))                deallocate(freq)
   if(allocated(fcoef))  then
-     ccl_del_device(fcoef)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:fcoef)
+#elif defined(_OPENACC)
+!$acc exit data delete(fcoef)
+#endif
      deallocate(fcoef)
   endif
   if(allocated(gcoef))  then
-     ccl_del_device(gcoef)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:gcoef)
+#elif defined(_OPENACC)
+!$acc exit data delete(gcoef)
+#endif
      deallocate(gcoef)
   endif
   if(allocated(field_v))  then
-     ccl_del_device(field_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:field_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(field_v)
+#endif
      deallocate(field_v)
   endif
   if(allocated(field_loc_v))  then
-     ccl_del_device(field_loc_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:field_loc_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(field_loc_v)
+#endif
      deallocate(field_loc_v)
   endif
   if(allocated(field))  then
-     ccl_del_device(field)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:field)
+#elif defined(_OPENACC)
+!$acc exit data delete(field)
+#endif
      deallocate(field)
   endif
   if(allocated(field_loc))  then
-     ccl_del_device(field_loc)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:field_loc)
+#elif defined(_OPENACC)
+!$acc exit data delete(field_loc)
+#endif
      deallocate(field_loc)
   endif
   if(allocated(field_dot))           deallocate(field_dot)
@@ -135,177 +153,345 @@ subroutine cgyro_cleanup
   if(allocated(gflux_tave))          deallocate(gflux_tave)
   if(allocated(recv_status))         deallocate(recv_status)
   if(allocated(source)) then
-      ccl_del_device(source)      
+#if defined(OMPGPU)
+!$omp target exit data map(release:source)
+#elif defined(_OPENACC)
+!$acc exit data delete(source)
+#endif
      deallocate(source)
   endif
   if(allocated(thfac_itor)) then
-      ccl_del_device(thfac_itor)
+#if defined(OMPGPU)
+!$omp target exit data map(release:thfac_itor)
+#elif defined(_OPENACC)
+!$acc exit data delete(thfac_itor)
+#endif
      deallocate(thfac_itor)
   endif
   if(allocated(h0_old)) then
-     ccl_del_device(h0_old)      
+#if defined(OMPGPU)
+!$omp target exit data map(release:h0_old)
+#elif defined(_OPENACC)
+!$acc exit data delete(h0_old)
+#endif
      deallocate(h0_old)
   endif
   if(allocated(rhs)) then
-     ccl_del_device(rhs)       
+#if defined(OMPGPU)
+!$omp target exit data map(release:rhs)
+#elif defined(_OPENACC)
+!$acc exit data delete(rhs)
+#endif
      deallocate(rhs)
   endif
   if(allocated(h_x)) then
-     ccl_del_device(h_x)       
+#if defined(OMPGPU)
+!$omp target exit data map(release:h_x)
+#elif defined(_OPENACC)
+!$acc exit data delete(h_x)
+#endif
      deallocate(h_x)
   endif
   if(allocated(g_x)) then
-     ccl_del_device(g_x)       
+#if defined(OMPGPU)
+!$omp target exit data map(release:g_x)
+#elif defined(_OPENACC)
+!$acc exit data delete(g_x)
+#endif
      deallocate(g_x)
   endif
   if(allocated(h0_x)) then
-     ccl_del_device(h0_x)        
+#if defined(OMPGPU)
+!$omp target exit data map(release:h0_x)
+#elif defined(_OPENACC)
+!$acc exit data delete(h0_x)
+#endif
      deallocate(h0_x)
   endif
   if(allocated(cap_h_c)) then
-     ccl_del_device(cap_h_c)       
+#if defined(OMPGPU)
+!$omp target exit data map(release:cap_h_c)
+#elif defined(_OPENACC)
+!$acc exit data delete(cap_h_c)
+#endif
      deallocate(cap_h_c)
   endif
   if(allocated(cap_h_ct))  then
-     ccl_del_device(cap_h_ct)       
+#if defined(OMPGPU)
+!$omp target exit data map(release:cap_h_ct)
+#elif defined(_OPENACC)
+!$acc exit data delete(cap_h_ct)
+#endif
      deallocate(cap_h_ct)
   endif
   if(allocated(cap_h_c_dot)) then
-     ccl_del_device(cap_h_c_dot)
+#if defined(OMPGPU)
+!$omp target exit data map(release:cap_h_c_dot)
+#elif defined(_OPENACC)
+!$acc exit data delete(cap_h_c_dot)
+#endif
      deallocate(cap_h_c_dot)
   endif
   if(allocated(cap_h_c_old)) then
-     ccl_del_device(cap_h_c_old)
+#if defined(OMPGPU)
+!$omp target exit data map(release:cap_h_c_old)
+#elif defined(_OPENACC)
+!$acc exit data delete(cap_h_c_old)
+#endif
      deallocate(cap_h_c_old)
   endif
   if(allocated(cap_h_c_old2)) then
-     ccl_del_device(cap_h_c_old2)
+#if defined(OMPGPU)
+!$omp target exit data map(release:cap_h_c_old2)
+#elif defined(_OPENACC)
+!$acc exit data delete(cap_h_c_old2)
+#endif
      deallocate(cap_h_c_old2)
   endif
   if(allocated(omega_cap_h)) then
-     ccl_del_device(omega_cap_h)        
+#if defined(OMPGPU)
+!$omp target exit data map(release:omega_cap_h)
+#elif defined(_OPENACC)
+!$acc exit data delete(omega_cap_h)
+#endif
      deallocate(omega_cap_h)
   endif
   if(allocated(omega_h)) then
-     ccl_del_device(omega_h)        
+#if defined(OMPGPU)
+!$omp target exit data map(release:omega_h)
+#elif defined(_OPENACC)
+!$acc exit data delete(omega_h)
+#endif
      deallocate(omega_h)
   endif
   if(allocated(omega_s)) then
-     ccl_del_device(omega_s)        
+#if defined(OMPGPU)
+!$omp target exit data map(release:omega_s)
+#elif defined(_OPENACC)
+!$acc exit data delete(omega_s)
+#endif
      deallocate(omega_s)
   endif
   if(allocated(omega_ss)) then
-     ccl_del_device(omega_ss)        
+#if defined(OMPGPU)
+!$omp target exit data map(release:omega_ss)
+#elif defined(_OPENACC)
+!$acc exit data delete(omega_ss)
+#endif
      deallocate(omega_ss)
   endif
   if(allocated(omega_sbeta)) then
-     ccl_del_device(omega_sbeta)        
+#if defined(OMPGPU)
+!$omp target exit data map(release:omega_sbeta)
+#elif defined(_OPENACC)
+!$acc exit data delete(omega_sbeta)
+#endif
      deallocate(omega_sbeta)
   endif
   if(allocated(jvec_c))  then
-     ccl_del_device(jvec_c)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:jvec_c)
+#elif defined(_OPENACC)
+!$acc exit data delete(jvec_c)
+#endif
      deallocate(jvec_c)
   endif
   if(allocated(jvec_c_nl))  then
-     ccl_del_device(jvec_c_nl)
+#if defined(OMPGPU)
+!$omp target exit data map(release:jvec_c_nl)
+#elif defined(_OPENACC)
+!$acc exit data delete(jvec_c_nl)
+#endif
      deallocate(jvec_c_nl)
   endif
   if(allocated(jvec_v))              deallocate(jvec_v)
   if(allocated(dvjvec_c)) then
-     ccl_del_device(dvjvec_c)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:dvjvec_c)
+#elif defined(_OPENACC)
+!$acc exit data delete(dvjvec_c)
+#endif
      deallocate(dvjvec_c)
   endif
   if(allocated(dvjvec_v)) then
-     ccl_del_device(dvjvec_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:dvjvec_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(dvjvec_v)
+#endif
      deallocate(dvjvec_v)
   endif
   if(allocated(jxvec_c))  then
      deallocate(jxvec_c)
   endif
   if(allocated(upfac1))   then
-     ccl_del_device(upfac1)
+#if defined(OMPGPU)
+!$omp target exit data map(release:upfac1)
+#elif defined(_OPENACC)
+!$acc exit data delete(upfac1)
+#endif
      deallocate(upfac1)
   endif
   if(allocated(upfac2))   then
-     ccl_del_device(upfac2)
+#if defined(OMPGPU)
+!$omp target exit data map(release:upfac2)
+#elif defined(_OPENACC)
+!$acc exit data delete(upfac2)
+#endif
      deallocate(upfac2)
   endif
   if(allocated(cap_h_v))  then
-     ccl_del_device(cap_h_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:cap_h_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(cap_h_v)
+#endif
      deallocate(cap_h_v)
   endif
   if(allocated(upwind_res_loc))   then
-     ccl_del_device(upwind_res_loc)
+#if defined(OMPGPU)
+!$omp target exit data map(release:upwind_res_loc)
+#elif defined(_OPENACC)
+!$acc exit data delete(upwind_res_loc)
+#endif
      deallocate(upwind_res_loc)
   endif
   if(allocated(upwind_res))   then
-     ccl_del_device(upwind_res)
+#if defined(OMPGPU)
+!$omp target exit data map(release:upwind_res)
+#elif defined(_OPENACC)
+!$acc exit data delete(upwind_res)
+#endif
      deallocate(upwind_res)
   endif
   if(allocated(upwind32_res_loc))   then
-     ccl_del_device(upwind32_res_loc)
+#if defined(OMPGPU)
+!$omp target exit data map(release:upwind32_res_loc)
+#elif defined(_OPENACC)
+!$acc exit data delete(upwind32_res_loc)
+#endif
      deallocate(upwind32_res_loc)
   endif
   if(allocated(upwind32_res))   then
-     ccl_del_device(upwind32_res)
+#if defined(OMPGPU)
+!$omp target exit data map(release:upwind32_res)
+#elif defined(_OPENACC)
+!$acc exit data delete(upwind32_res)
+#endif
      deallocate(upwind32_res)
   endif
   if(allocated(fA_nl))   then
-     ccl_del_device(fA_nl)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fA_nl)
+#elif defined(_OPENACC)
+!$acc exit data delete(fA_nl)
+#endif
      deallocate(fA_nl)
   endif
   if(allocated(fB_nl))   then
-     ccl_del_device(fB_nl)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fB_nl)
+#elif defined(_OPENACC)
+!$acc exit data delete(fB_nl)
+#endif
      deallocate(fB_nl)
   endif
   if(allocated(fA_nl32))   then
-     ccl_del_device(fA_nl32)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fA_nl32)
+#elif defined(_OPENACC)
+!$acc exit data delete(fA_nl32)
+#endif
      deallocate(fA_nl32)
   endif
   if(allocated(fB_nl32))   then
-     ccl_del_device(fB_nl32)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fB_nl32)
+#elif defined(_OPENACC)
+!$acc exit data delete(fB_nl32)
+#endif
      deallocate(fB_nl32)
   endif
   if(allocated(g_nl))   then
-     ccl_del_device(g_nl)
+#if defined(OMPGPU)
+!$omp target exit data map(release:g_nl)
+#elif defined(_OPENACC)
+!$acc exit data delete(g_nl)
+#endif
      deallocate(g_nl)
   endif
   if(allocated(g_nl32))   then
-     ccl_del_device(g_nl32)
+#if defined(OMPGPU)
+!$omp target exit data map(release:g_nl32)
+#elif defined(_OPENACC)
+!$acc exit data delete(g_nl32)
+#endif
      deallocate(g_nl32)
   endif
   if(allocated(fpackA))   then
-     ccl_del_device(fpackA)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fpackA)
+#elif defined(_OPENACC)
+!$acc exit data delete(fpackA)
+#endif
      deallocate(fpackA)
   endif
   if(allocated(fpackB))   then
-     ccl_del_device(fpackB)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fpackB)
+#elif defined(_OPENACC)
+!$acc exit data delete(fpackB)
+#endif
      deallocate(fpackB)
   endif
   if(allocated(fpackA32))   then
-     ccl_del_device(fpackA32)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fpackA32)
+#elif defined(_OPENACC)
+!$acc exit data delete(fpackA32)
+#endif
      deallocate(fpackA32)
   endif
   if(allocated(fpackB32))   then
-     ccl_del_device(fpackB32)
+#if defined(OMPGPU)
+!$omp target exit data map(release:fpackB32)
+#elif defined(_OPENACC)
+!$acc exit data delete(fpackB32)
+#endif
      deallocate(fpackB32)
   endif
   if(allocated(gpack))   then
-     ccl_del_device(gpack)
+#if defined(OMPGPU)
+!$omp target exit data map(release:gpack)
+#elif defined(_OPENACC)
+!$acc exit data delete(gpack)
+#endif
      deallocate(gpack)
   endif
   if(allocated(gpack32))   then
-     ccl_del_device(gpack32)
+#if defined(OMPGPU)
+!$omp target exit data map(release:gpack32)
+#elif defined(_OPENACC)
+!$acc exit data delete(gpack32)
+#endif
      deallocate(gpack32)
   endif
   call deallocate_cmat
   call deallocate_cmat_fp32
   if (allocated(cmat_stripes)) then
-     ccl_del_bigdevice(cmat_stripes)
+#if defined(OMPGPU)
+!$omp target exit data map(release:cmat_stripes) if (gpu_bigmem_flag > 0)
+#elif defined(_OPENACC)
+!$acc exit data delete(cmat_stripes) if (gpu_bigmem_flag > 0)
+#endif
      deallocate(cmat_stripes)
   endif
     if (allocated(cmat_simple)) then
-     ccl_del_device(cmat_simple)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:cmat_simple)
+#elif defined(_OPENACC)
+!$acc exit data delete(cmat_simple)
+#endif
      deallocate(cmat_simple)
   endif
 
@@ -333,75 +519,147 @@ subroutine cgyro_cleanup
 
 #ifdef CGYRO_GPU_FFT
   if(allocated(fxmany))    then
-     ccl_del_device(fxmany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:fxmany)
+#elif defined(_OPENACC)
+!$acc exit data delete(fxmany)
+#endif
      deallocate(fxmany)
   endif
   if(allocated(gxmany))    then
-     ccl_del_device(gxmany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:gxmany)
+#elif defined(_OPENACC)
+!$acc exit data delete(gxmany)
+#endif
      deallocate(gxmany)
   endif
   if(allocated(fymany))    then
-     ccl_del_device(fymany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:fymany)
+#elif defined(_OPENACC)
+!$acc exit data delete(fymany)
+#endif
      deallocate(fymany)
   endif
   if(allocated(gymany))    then
-     ccl_del_device(gymany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:gymany)
+#elif defined(_OPENACC)
+!$acc exit data delete(gymany)
+#endif
      deallocate(gymany)
   endif
   if(allocated(uxmany))    then
-      ccl_del_device(uxmany)    
+#if defined(OMPGPU)
+!$omp target exit data map(release:uxmany)
+#elif defined(_OPENACC)
+!$acc exit data delete(uxmany)
+#endif
      deallocate(uxmany)
   endif
   if(allocated(uymany))    then
-     ccl_del_device(uymany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:uymany)
+#elif defined(_OPENACC)
+!$acc exit data delete(uymany)
+#endif
      deallocate(uymany)
   endif
   if(allocated(vxmany))     then
-     ccl_del_device(vxmany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:vxmany)
+#elif defined(_OPENACC)
+!$acc exit data delete(vxmany)
+#endif
      deallocate(vxmany)
   endif
   if(allocated(vymany))     then
-     ccl_del_device(vymany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:vymany)
+#elif defined(_OPENACC)
+!$acc exit data delete(vymany)
+#endif
      deallocate(vymany)
   endif
   if(allocated(uvmany))     then
-     ccl_del_device(uvmany)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:uvmany)
+#elif defined(_OPENACC)
+!$acc exit data delete(uvmany)
+#endif
      deallocate(uvmany)
   endif
   if(allocated(fxmany32))    then
-     ccl_del_device(fxmany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:fxmany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(fxmany32)
+#endif
      deallocate(fxmany32)
   endif
   if(allocated(gxmany32))    then
-     ccl_del_device(gxmany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:gxmany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(gxmany32)
+#endif
      deallocate(gxmany32)
   endif
   if(allocated(fymany32))    then
-     ccl_del_device(fymany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:fymany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(fymany32)
+#endif
      deallocate(fymany32)
   endif
   if(allocated(gymany32))    then
-     ccl_del_device(gymany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:gymany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(gymany32)
+#endif
      deallocate(gymany32)
   endif
   if(allocated(uxmany32))    then
-      ccl_del_device(uxmany32)    
+#if defined(OMPGPU)
+!$omp target exit data map(release:uxmany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(uxmany32)
+#endif
      deallocate(uxmany32)
   endif
   if(allocated(uymany32))    then
-     ccl_del_device(uymany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:uymany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(uymany32)
+#endif
      deallocate(uymany32)
   endif
   if(allocated(vxmany32))     then
-     ccl_del_device(vxmany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:vxmany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(vxmany32)
+#endif
      deallocate(vxmany32)
   endif
   if(allocated(vymany32))     then
-     ccl_del_device(vymany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:vymany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(vymany32)
+#endif
      deallocate(vymany32)
   endif
   if(allocated(uvmany32))     then
-     ccl_del_device(uvmany32)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:uvmany32)
+#elif defined(_OPENACC)
+!$acc exit data delete(uvmany32)
+#endif
      deallocate(uvmany32)
   endif
 #endif    
@@ -411,13 +669,25 @@ subroutine cgyro_cleanup
   !!!!!!!!!!!!!!!!!!!!!!!!!!
   
   if(allocated(px))  then
-     ccl_del_device(px)      
+#if defined(OMPGPU)
+!$omp target exit data map(release:px)
+#elif defined(_OPENACC)
+!$acc exit data delete(px)
+#endif
      deallocate(px)
   endif
   
-     ccl_del_device(z)
+#if defined(OMPGPU)
+!$omp target exit data map(release:z)
+#elif defined(_OPENACC)
+!$acc exit data delete(z)
+#endif
 
-     ccl_del_device(temp) 
+#if defined(OMPGPU)
+!$omp target exit data map(release:temp)
+#elif defined(_OPENACC)
+!$acc exit data delete(temp)
+#endif
   
   
   !!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -429,7 +699,11 @@ subroutine cgyro_cleanup
   if(allocated(cderiv))           deallocate(cderiv)
   if(allocated(uderiv))           deallocate(uderiv)
   if(allocated(c_wave)) then
-     ccl_del_device(c_wave)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:c_wave)
+#elif defined(_OPENACC)
+!$acc exit data delete(c_wave)
+#endif
      deallocate(c_wave)
   endif
   if(allocated(hzf))              deallocate(hzf)
@@ -440,37 +714,65 @@ subroutine cgyro_cleanup
   !!!!!!!!!!!!!!!!!!!!!!!!!!
 
   if(allocated(ie_v)) then
-     ccl_del_device(ie_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:ie_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(ie_v)
+#endif
      deallocate(ie_v)
   endif
 
   if(allocated(ix_v)) then
-     ccl_del_device(ix_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:ix_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(ix_v)
+#endif
      deallocate(ix_v)
   endif
 
   if(allocated(is_v)) then
-     ccl_del_device(is_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:is_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(is_v)
+#endif
      deallocate(is_v)
   endif
 
   if(allocated(iv_v)) then
-     ccl_del_device(iv_v)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:iv_v)
+#elif defined(_OPENACC)
+!$acc exit data delete(iv_v)
+#endif
      deallocate(iv_v)
   endif
 
     if(allocated(ir_c)) then
-     ccl_del_device(ir_c)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:ir_c)
+#elif defined(_OPENACC)
+!$acc exit data delete(ir_c)
+#endif
      deallocate(ir_c)
   endif
 
   if(allocated(it_c)) then
-     ccl_del_device(it_c)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:it_c)
+#elif defined(_OPENACC)
+!$acc exit data delete(it_c)
+#endif
      deallocate(it_c)
   endif
 
   if(allocated(ic_c)) then
-     ccl_del_device(ic_c)     
+#if defined(OMPGPU)
+!$omp target exit data map(release:ic_c)
+#elif defined(_OPENACC)
+!$acc exit data delete(ic_c)
+#endif
      deallocate(ic_c)
   endif
 

--- a/cgyro/src/cgyro_nl_fftw.F90
+++ b/cgyro/src/cgyro_nl_fftw.F90
@@ -776,8 +776,8 @@ subroutine cgyro_fft_z2d(plan, indata, outdata)
 #else
   integer(c_int), intent(inout) :: plan
 #endif
-  complex, dimension(:,:,:), intent(inout) :: indata
-  real, dimension(:,:,:), intent(inout)    :: outdata
+  complex, dimension(:,:,:), target, intent(inout) :: indata
+  real, dimension(:,:,:), target, intent(inout)    :: outdata
   !-----------------------------------
   integer :: rc
 
@@ -786,7 +786,13 @@ subroutine cgyro_fft_z2d(plan, indata, outdata)
 #if defined(MKLGPU)
 !$omp target data map(tofrom: indata, outdata)
 #else
+
+#if defined(OMPGPU_DEVICE_ADDR)
+!$omp target data use_device_addr(indata, outdata)
+#else
 !$omp target data use_device_ptr(indata, outdata)
+#endif
+
 #endif
 
 #else
@@ -847,8 +853,8 @@ subroutine cgyro_fft_c2r(plan, indata, outdata)
 #else
   integer(c_int), intent(inout) :: plan
 #endif
-  complex(KIND=REAL32), dimension(:,:,:), intent(inout) :: indata
-  real(KIND=REAL32), dimension(:,:,:), intent(inout)    :: outdata
+  complex(KIND=REAL32), dimension(:,:,:), target, intent(inout) :: indata
+  real(KIND=REAL32), dimension(:,:,:), target, intent(inout)    :: outdata
   !-----------------------------------
   integer :: rc
 
@@ -857,7 +863,13 @@ subroutine cgyro_fft_c2r(plan, indata, outdata)
 #if defined(MKLGPU)
 !$omp target data map(tofrom: indata, outdata)
 #else
+
+#if defined(OMPGPU_DEVICE_ADDR)
+!$omp target data use_device_addr(indata, outdata)
+#else
 !$omp target data use_device_ptr(indata, outdata)
+#endif
+
 #endif
 
 #else
@@ -917,8 +929,8 @@ subroutine cgyro_fft_d2z(plan, indata, outdata)
 #else
   integer(c_int), intent(inout) :: plan
 #endif
-  real, dimension(:,:,:), intent(inout)    :: indata
-  complex, dimension(:,:,:), intent(inout) :: outdata
+  real, dimension(:,:,:), target, intent(inout)    :: indata
+  complex, dimension(:,:,:), target, intent(inout) :: outdata
   !-----------------------------------
   integer :: rc
 
@@ -927,7 +939,13 @@ subroutine cgyro_fft_d2z(plan, indata, outdata)
 #if defined(MKLGPU)
 !$omp target data map(tofrom: indata, outdata)
 #else
+
+#if defined(OMPGPU_DEVICE_ADDR)
+!$omp target data use_device_addr(indata, outdata)
+#else
 !$omp target data use_device_ptr(indata, outdata)
+#endif
+
 #endif
 
 #else
@@ -988,8 +1006,8 @@ subroutine cgyro_fft_r2c(plan, indata, outdata)
 #else
   integer(c_int), intent(inout) :: plan
 #endif
-  real(KIND=REAL32), dimension(:,:,:), intent(inout)    :: indata
-  complex(KIND=REAL32), dimension(:,:,:), intent(inout) :: outdata
+  real(KIND=REAL32), dimension(:,:,:), target, intent(inout)    :: indata
+  complex(KIND=REAL32), dimension(:,:,:), target, intent(inout) :: outdata
   !-----------------------------------
   integer :: rc
 
@@ -998,7 +1016,13 @@ subroutine cgyro_fft_r2c(plan, indata, outdata)
 #if defined(MKLGPU)
 !$omp target data map(tofrom: indata, outdata)
 #else
+
+#if defined(OMPGPU_DEVICE_ADDR)
+!$omp target data use_device_addr(indata, outdata)
+#else
 !$omp target data use_device_ptr(indata, outdata)
+#endif
+
 #endif
 
 #else

--- a/cgyro/src/cgyro_parallel_lib.F90
+++ b/cgyro/src/cgyro_parallel_lib.F90
@@ -63,100 +63,6 @@ module parallel_lib
 
 contains
 
-#ifdef DISABLE_GPUDIRECT_MPI
-
-#if defined(OMPGPU)
-
-#define cpl_use_device1(finout) \
-!$omp target update from(finout)
-#define cpl_release_device1(finout) \
-!$omp target update to(finout)
-
-#define cpl_use_device(fin,fout) \
-!$omp target update from(fin)
-#define cpl_release_device(fin,fout) \
-!$omp target update to(fout)
-  ! used for async, so no copy at this point
-#define cpl_unbind_device(fin,fout)
-
-#define cpl_finalize_device(fin,fout) \
-!$omp target update to(fout)
-
-#elif defined(_OPENACC)
-
-#define cpl_use_device1(finout) \
-!$acc update host(finout)
-#define cpl_release_device1(finout) \
-!$acc update device(finout)
-
-#define cpl_use_device(fin,fout) \
-!$acc update host(fin)
-#define cpl_release_device(fin,fout) \
-!$acc update device(fout)
-  ! used for async, so no copy at this point
-#define cpl_unbind_device(fin,fout)
-
-#define cpl_finalize_device(fin,fout) \
-!$acc update device(fout)
-
-#else
-  ! no devices, no-ops only
-#define cpl_use_device1(finout) 
-#define cpl_release_device1(finout) 
-#define cpl_use_device(fin,fout) 
-#define cpl_release_device(fin,fout) 
-#define cpl_unbind_device(fin,fout)
-#define cpl_finalize_device(fin,fout) 
-
-#endif
-
-#else
-
-#if defined(OMPGPU)
-
-#define cpl_use_device1(finout) \
-!$omp target data use_device_addr(finout)
-#define cpl_release_device1(finout) \
-!$omp end target data
-
-#define cpl_use_device(fin,fout) \
-!$omp target data use_device_addr(fin,fout)
-#define cpl_release_device(fin,fout) \
-!$omp end target data
-#define cpl_unbind_device(fin,fout) \
-!$omp end target data
-  ! no-op, as there was no copying involved
-#define cpl_finalize_device(fin,fout)
-
-#elif defined(_OPENACC)
-
-#define cpl_use_device1(finout) \
-!$acc host_data use_device(finout)
-#define cpl_release_device1(finout) \
-!$acc end host_data
-
-#define cpl_use_device(fin,fout) \
-!$acc host_data use_device(fin,fout)
-#define cpl_release_device(fin,fout) \
-!$acc end host_data
-#define cpl_unbind_device(fin,fout) \
-!$acc end host_data
-  ! no-op, as there was no copying involved
-#define cpl_finalize_device(fin,fout)
-
-#else
-  ! no devices, no-ops only
-#define cpl_use_device1(finout) 
-#define cpl_release_device1(finout) 
-#define cpl_use_device(fin,fout) 
-#define cpl_release_device(fin,fout) 
-#define cpl_unbind_device(fin,fout)
-#define cpl_finalize_device(fin,fout) 
-
-#endif
-
-#endif
-
   !=========================================================
   !  parallel_lib_f -> f(ni_loc,nj) -> g(nj_loc,ni) 
   !  parallel_lib_r -> g(nj_loc,ni) -> f(ni_loc,nj)
@@ -247,7 +153,19 @@ contains
     complex, intent(inout), dimension(:,:,:) :: ft
     integer :: ierr
 
-    cpl_use_device(fsendf,ft)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(fsendf)
+#elif defined(_OPENACC)
+!$acc update host(fsendf)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(fsendf,ft)
+#elif defined(_OPENACC)
+!$acc host_data use_device(fsendf,ft)
+#endif
+#endif
 
     call MPI_ALLTOALL(fsendf, &
          nsend, &
@@ -258,7 +176,19 @@ contains
          lib_comm, &
          ierr)
 
-    cpl_release_device(fsendf,ft)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(ft)
+#elif defined(_OPENACC)
+!$acc update device(ft)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_lib_f_i_do_gpu
 
@@ -296,7 +226,19 @@ contains
 
     integer :: ierr
 
-    cpl_use_device(fsendr,f)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(fsendr)
+#elif defined(_OPENACC)
+!$acc update host(fsendr)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(fsendr,f)
+#elif defined(_OPENACC)
+!$acc host_data use_device(fsendr,f)
+#endif
+#endif
 
     call MPI_ALLTOALL(fsendr, &
          nsend, &
@@ -307,7 +249,19 @@ contains
          lib_comm, &
          ierr)
 
-    cpl_release_device(fsendr,f)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(f)
+#elif defined(_OPENACC)
+!$acc update device(f)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_lib_r_do_gpu
 
@@ -485,7 +439,19 @@ contains
     complex, intent(inout), dimension(:,:,:,:) :: field_v
     integer :: ierr
 
-    cpl_use_device(field_loc_v,field_v)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(field_loc_v)
+#elif defined(_OPENACC)
+!$acc update host(field_loc_v)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(field_loc_v,field_v)
+#elif defined(_OPENACC)
+!$acc host_data use_device(field_loc_v,field_v)
+#endif
+#endif
 
     call MPI_ALLGATHER(field_loc_v(:,:,:,:),&
          size(field_loc_v(:,:,:,:)),&
@@ -496,7 +462,19 @@ contains
          lib_comm,&
          ierr)
 
-    cpl_release_device(field_loc_v,field_v)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(field_v)
+#elif defined(_OPENACC)
+!$acc update device(field_v)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_lib_collect_field_gpu
 
@@ -569,7 +547,19 @@ contains
     complex, intent(inout), dimension(:,:,:) :: field
     integer :: ierr
 
-    cpl_use_device(field_loc,field)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(field_loc)
+#elif defined(_OPENACC)
+!$acc update host(field_loc)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(field_loc,field)
+#elif defined(_OPENACC)
+!$acc host_data use_device(field_loc,field)
+#endif
+#endif
 
     call MPI_ALLREDUCE(field_loc(:,:,:),&
           field(:,:,:),&
@@ -579,7 +569,19 @@ contains
           flib_comm,&
           ierr)
 
-    cpl_release_device(field_loc,field)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(field)
+#elif defined(_OPENACC)
+!$acc update device(field)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_flib_sum_field_gpu
 
@@ -622,7 +624,19 @@ contains
     complex, intent(inout), dimension(:,:,:) :: upwind
     integer :: ierr
 
-    cpl_use_device(upwind_loc,upwind)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(upwind_loc)
+#elif defined(_OPENACC)
+!$acc update host(upwind_loc)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(upwind_loc,upwind)
+#elif defined(_OPENACC)
+!$acc host_data use_device(upwind_loc,upwind)
+#endif
+#endif
 
     call MPI_ALLREDUCE(upwind_loc(:,:,:),&
           upwind(:,:,:),&
@@ -632,7 +646,19 @@ contains
           clib_comm,&
           ierr)
 
-    cpl_release_device(upwind_loc,upwind)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(upwind)
+#elif defined(_OPENACC)
+!$acc update device(upwind)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_clib_sum_upwind
 
@@ -648,7 +674,19 @@ contains
     complex(KIND=REAL32), intent(inout), dimension(:,:,:) :: upwind
     integer :: ierr
 
-    cpl_use_device(upwind_loc,upwind)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(upwind_loc)
+#elif defined(_OPENACC)
+!$acc update host(upwind_loc)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(upwind_loc,upwind)
+#elif defined(_OPENACC)
+!$acc host_data use_device(upwind_loc,upwind)
+#endif
+#endif
 
     call MPI_ALLREDUCE(upwind_loc(:,:,:),&
           upwind(:,:,:),&
@@ -658,7 +696,19 @@ contains
           clib_comm,&
           ierr)
 
-    cpl_release_device(upwind_loc,upwind)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(upwind)
+#elif defined(_OPENACC)
+!$acc update device(upwind)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_clib_sum_upwind32
 
@@ -742,7 +792,19 @@ contains
     integer :: ierr
     !-------------------------------------------------------
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
     call MPI_ALLTOALL(x, &
          nkeep*nk_loc*nsx, &
@@ -753,7 +815,19 @@ contains
          slib_comm, &
          ierr)
 
-    cpl_release_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_f_nc
 
@@ -775,7 +849,19 @@ contains
 
 #else
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
    call MPI_IALLTOALL(x, &
          nkeep*nk_loc*nsx, &
@@ -787,7 +873,13 @@ contains
          req, &
          ierr)
 
-    cpl_unbind_device(x,xt)
+#ifndef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
 #endif
 
@@ -808,7 +900,19 @@ contains
     integer :: ierr
     !-------------------------------------------------------
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
     call MPI_ALLTOALL(x, &
          nkeep*nk_loc*nsx, &
@@ -819,7 +923,19 @@ contains
          slib_comm, &
          ierr)
 
-    cpl_release_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_f_nc32
 
@@ -842,7 +958,19 @@ contains
 
 #else
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
    call MPI_IALLTOALL(x, &
          nkeep*nk_loc*nsx, &
@@ -854,7 +982,13 @@ contains
          req, &
          ierr)
 
-    cpl_unbind_device(x,xt)
+#ifndef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
 #endif
 
@@ -881,7 +1015,13 @@ contains
          istat, &
          ierr)
 
-    cpl_finalize_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#endif
 
 #endif
    !else, noop
@@ -910,7 +1050,13 @@ contains
          istat, &
          ierr)
 
-    cpl_finalize_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#endif
 
 #endif
    !else, noop
@@ -931,7 +1077,19 @@ contains
     integer :: ierr
     !-------------------------------------------------------
 
-    cpl_use_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(xt)
+#elif defined(_OPENACC)
+!$acc update host(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(xt,x)
+#elif defined(_OPENACC)
+!$acc host_data use_device(xt,x)
+#endif
+#endif
 
     call MPI_ALLTOALL(xt, &
          nkeep*nk_loc*nsx, &
@@ -942,7 +1100,19 @@ contains
          slib_comm, &
          ierr)
 
-    cpl_release_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(x)
+#elif defined(_OPENACC)
+!$acc update device(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_r_nc
 
@@ -959,7 +1129,19 @@ contains
     integer :: ierr
     !-------------------------------------------------------
 
-    cpl_use_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(xt)
+#elif defined(_OPENACC)
+!$acc update host(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(xt,x)
+#elif defined(_OPENACC)
+!$acc host_data use_device(xt,x)
+#endif
+#endif
 
     call MPI_ALLTOALL(xt, &
          nkeep*nk_loc*nsx, &
@@ -970,7 +1152,19 @@ contains
          slib_comm, &
          ierr)
 
-    cpl_release_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(x)
+#elif defined(_OPENACC)
+!$acc update device(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_r_nc32
 
@@ -992,7 +1186,19 @@ contains
 
 #else
 
-    cpl_use_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(xt)
+#elif defined(_OPENACC)
+!$acc update host(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(xt,x)
+#elif defined(_OPENACC)
+!$acc host_data use_device(xt,x)
+#endif
+#endif
 
     call MPI_IALLTOALL(xt, &
          nkeep*nk_loc*nsx, &
@@ -1004,7 +1210,13 @@ contains
          req, &
          ierr)
 
-    cpl_unbind_device(xt,x)
+#ifndef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 #endif
 
   end subroutine parallel_slib_r_nc_async
@@ -1028,7 +1240,19 @@ contains
 
 #else
 
-    cpl_use_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(xt)
+#elif defined(_OPENACC)
+!$acc update host(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(xt,x)
+#elif defined(_OPENACC)
+!$acc host_data use_device(xt,x)
+#endif
+#endif
 
     call MPI_IALLTOALL(xt, &
          nkeep*nk_loc*nsx, &
@@ -1040,7 +1264,13 @@ contains
          req, &
          ierr)
 
-    cpl_unbind_device(xt,x)
+#ifndef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 #endif
 
   end subroutine parallel_slib_r_nc32_async
@@ -1066,7 +1296,13 @@ contains
          istat, &
          ierr)
 
-    cpl_finalize_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(x)
+#elif defined(_OPENACC)
+!$acc update device(x)
+#endif
+#endif
 
 #endif
    !else, noop
@@ -1094,7 +1330,13 @@ contains
          istat, &
          ierr)
 
-    cpl_finalize_device(xt,x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(x)
+#elif defined(_OPENACC)
+!$acc update device(x)
+#endif
+#endif
 
 #endif
    !else, noop
@@ -1118,7 +1360,19 @@ contains
     integer :: ierr
     !-------------------------------------------------------
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
     call MPI_ALLTOALL(x, &
          nels1*nels2*nels3*nk_loc, &
@@ -1129,7 +1383,19 @@ contains
          slib_comm, &
          ierr)
 
-    cpl_release_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_f_fd
 
@@ -1150,7 +1416,19 @@ contains
     call parallel_slib_f_fd(nels1,nels2,nels3,x,xt)
 #else
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
    call MPI_IALLTOALL(x, &
          nels1*nels2*nels3*nk_loc, &
@@ -1162,7 +1440,13 @@ contains
          req, &
          ierr)
 
-    cpl_unbind_device(x,xt)
+#ifndef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
 #endif
 
@@ -1183,7 +1467,19 @@ contains
     integer :: ierr
     !-------------------------------------------------------
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
     call MPI_ALLTOALL(x, &
          nels1*nels2*nels3*nk_loc, &
@@ -1194,7 +1490,19 @@ contains
          slib_comm, &
          ierr)
 
-    cpl_release_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_f_fd32
 
@@ -1216,7 +1524,19 @@ contains
     call parallel_slib_f_fd32(nels1,nels2,nels3,x,xt)
 #else
 
-    cpl_use_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x,xt)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x,xt)
+#endif
+#endif
 
    call MPI_IALLTOALL(x, &
          nels1*nels2*nels3*nk_loc, &
@@ -1228,7 +1548,13 @@ contains
          req, &
          ierr)
 
-    cpl_unbind_device(x,xt)
+#ifndef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
 #endif
 
@@ -1255,7 +1581,13 @@ contains
          istat, &
          ierr)
 
-    cpl_finalize_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#endif
 
 #endif
   ! else noop
@@ -1285,7 +1617,13 @@ contains
          istat, &
          ierr)
 
-    cpl_finalize_device(x,xt)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(xt)
+#elif defined(_OPENACC)
+!$acc update device(xt)
+#endif
+#endif
 
 #endif
   ! else noop
@@ -1310,7 +1648,19 @@ contains
     !-------------------------------------------------------
 
     nels = nels1*nels2*nels3*nels4*nels5
-    cpl_use_device1(x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x)
+#endif
+#endif
 
     call MPI_ALLTOALL(MPI_IN_PLACE, &
          nels, &
@@ -1321,7 +1671,19 @@ contains
          slib_comm, &
          ierr)
 
-   cpl_release_device1(x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(x)
+#elif defined(_OPENACC)
+!$acc update device(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_distribute_real
 
@@ -1341,7 +1703,19 @@ contains
     !-------------------------------------------------------
 
     nels = nels1*nels2*nels3*nels4*nels5
-    cpl_use_device1(x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update from(x)
+#elif defined(_OPENACC)
+!$acc update host(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp target data use_device_addr(x)
+#elif defined(_OPENACC)
+!$acc host_data use_device(x)
+#endif
+#endif
 
     call MPI_ALLTOALL(MPI_IN_PLACE, &
          nels, &
@@ -1352,7 +1726,19 @@ contains
          slib_comm, &
          ierr)
 
-   cpl_release_device1(x)
+#ifdef DISABLE_GPUDIRECT_MPI
+#if defined(OMPGPU)
+!$omp target update to(x)
+#elif defined(_OPENACC)
+!$acc update device(x)
+#endif
+#else
+#if defined(OMPGPU)
+!$omp end target data
+#elif defined(_OPENACC)
+!$acc end host_data
+#endif
+#endif
 
   end subroutine parallel_slib_distribute_real32
 
@@ -1392,4 +1778,3 @@ contains
   end subroutine parallel_lib_clean
   
 end module parallel_lib
-

--- a/cgyro/src/cgyro_step_collision.F90
+++ b/cgyro/src/cgyro_step_collision.F90
@@ -395,9 +395,17 @@ subroutine cgyro_calc_collision_gpu_fp32(nj_loc,cmat_gpu)
 
   vcount = nv/nv_loc
 #if defined(OMPGPU)
+
+#if defined(OMPGPU_DEVICE_ADDR)
+!$omp target teams distribute parallel do simd collapse(4) &
+!$omp&         private(b_re,b_im,cval,ivp,iv) firstprivate(nproc,nj_loc,nv,n_sim,vcount) &
+!$omp&         private(k,ic,j,ic_loc,ism) has_device_addr(cmat_gpu)
+#else
 !$omp target teams distribute parallel do simd collapse(4) &
 !$omp&         private(b_re,b_im,cval,ivp,iv) firstprivate(nproc,nj_loc,nv,n_sim,vcount) &
 !$omp&         private(k,ic,j,ic_loc,ism) is_device_ptr(cmat_gpu)
+#endif
+
 #else
 !$acc parallel loop collapse(4) gang vector &
 !$acc& private(b_re,b_im,cval,ivp,iv) firstprivate(nproc,nj_loc,nv,n_sim,vcount) &
@@ -452,9 +460,17 @@ subroutine cgyro_calc_collision_gpu_fp64(nj_loc,cmat_gpu)
 
   vcount = nv/nv_loc
 #if defined(OMPGPU)
+
+#if defined(OMPGPU_DEVICE_ADDR)
+!$omp target teams distribute parallel do simd collapse(4) &
+!$omp&         private(b_re,b_im,cval,ivp,iv) firstprivate(nproc,nj_loc,nv,n_sim,vcount) &
+!$omp&         private(k,ic,j,ic_loc,ism) has_device_addr(cmat_gpu)
+#else
 !$omp target teams distribute parallel do simd collapse(4) &
 !$omp&         private(b_re,b_im,cval,ivp,iv) firstprivate(nproc,nj_loc,nv,n_sim,vcount) &
 !$omp&         private(k,ic,j,ic_loc,ism) is_device_ptr(cmat_gpu)
+#endif
+
 #else
 !$acc parallel loop collapse(4) gang vector &
 !$acc& private(b_re,b_im,cval,ivp,iv) firstprivate(nproc,nj_loc,nv,n_sim,vcount) &

--- a/platform/build/make.inc.FRONTIER
+++ b/platform/build/make.inc.FRONTIER
@@ -18,7 +18,7 @@ F77 = ${FC}
 ifneq ($(GACODE_OMPGPU),1)
 FACC   =-hacc -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 else
-FACC = -DOMPGPU -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
+FACC = -DOMPGPU -DOMPGPU_DEVICE_ADDR -DHIPGPU -DGACODE_GPU_AMD -I${HIPFORT_DIR}/include/hipfort/amdgcn -hacc_model=auto_async_none:no_fast_addr:no_deep_copy
 endif
 FOMP   =-homp
 FMATH  =-s real64

--- a/platform/env/env.FRONTIER
+++ b/platform/env/env.FRONTIER
@@ -15,16 +15,13 @@ if [ -n "$SSH_TTY" ] ; then
  fi
 fi
 
-module load cpe/23.09
+module load cpe/26.03
 
 module load craype-accel-amd-gfx90a
 module load cray-python
 module load cray-mpich
-#module load hipfort
-
-module load rocm/5.6.0
-module use /lustre/orion/world-shared/stf006/reubendb/sw/frontier/modulefiles
-module load hipfort/cce16.0.1-rocm5.6
+module load rocm
+module load hipfort
 
 export LD_LIBRARY_PATH="${CRAY_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH}"
 


### PR DESCRIPTION
The compiler and ROCm version we relied on Frontier is deprecated, so we must move to a newer version.
A few changes were needed to have CGYRO compiled with the newer compilers.

Code changes are a no-op for the other platforms.