### PR TITLE
Fix stack overflow in TGLF filter when unstable modes exceed maxmodes

### DIFF
--- a/tglf/src/tglf_LS.f90
+++ b/tglf/src/tglf_LS.f90
@@ -288,7 +288,7 @@ if(new_matrix)then
             nb_of_unstable_modes = nb_of_unstable_modes + 1
           endif
         enddo
-        CALL sort_eigenvalues(nb_of_unstable_modes,jmax)
+        CALL sort_eigenvalues(MIN(nb_of_unstable_modes,maxmodes),jmax)
 
         do imax = 1, MIN(nb_of_unstable_modes,maxmodes)
           is_even = .false.


### PR DESCRIPTION
When FILTER < 0, tglf_LS counts all unstable eigenvalues into nb_of_unstable_modes and passes it to sort_eigenvalues, which writes sorted_index(1:nsorted) into jmax(maxmodes). With spurious modes (wide WIDTH, low shear and q), nb_of_unstable_modes can exceed maxmodes, causing an out-of-bounds write and a stack-smashing crash.

Cap the count at maxmodes, matching the existing MIN() guard on the subsequent loop, per recommendation by @emil-fransson (https://github.com/gafusion/gacode/issues/496).